### PR TITLE
Fix docs tutorials in dark mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
 [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) convention.
 
+## [0.1.6] - 2023-04-28
+
+- Fix - `.ipynb` output in tutorials is not visible in dark mode.
+
 ## [0.1.5] - 2023-03-02
 
 - Add - `surgery` schema
@@ -42,6 +46,7 @@ Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
 - Add - `subject` schema
 - Add - `genotyping` schema
 
+[0.1.6]: https://github.com/datajoint/element-animal/releases/tag/0.1.6
 [0.1.5]: https://github.com/datajoint/element-animal/releases/tag/0.1.5
 [0.1.4]: https://github.com/datajoint/element-animal/releases/tag/0.1.4
 [0.1.3]: https://github.com/datajoint/element-animal/releases/tag/0.1.3

--- a/docs/src/.overrides/assets/stylesheets/extra.css
+++ b/docs/src/.overrides/assets/stylesheets/extra.css
@@ -91,3 +91,7 @@ html a[title="YouTube"].md-social__link svg {
     /* previous/next text */
     /* --md-footer-fg-color: var(--dj-white); */
 }
+
+[data-md-color-scheme="slate"] .jupyter-wrapper .Table Td {
+    color: var(--dj-black)
+}

--- a/element_animal/version.py
+++ b/element_animal/version.py
@@ -1,2 +1,2 @@
 """Package metadata."""
-__version__ = "0.1.5"
+__version__ = "0.1.6"


### PR DESCRIPTION
This PR fixes the output of tutorial notebooks when viewed in dark mode within the documentation.

The following tasks are a part of this PR: 

- [x] Add docs fix to `extra.css`.
- [x] Update CHANGELOG.
- [x] Update version.py.
- [ ] Push an updated tag after the PR is merged.