### PR TITLE
Fix dark mode and CI/CD issues

### DIFF
--- a/.github/workflows/u24_element_release_call.yml
+++ b/.github/workflows/u24_element_release_call.yml
@@ -17,7 +17,6 @@ jobs:
     secrets:
       TWINE_USERNAME: ${{secrets.TWINE_TEST_USERNAME}}
       TWINE_PASSWORD: ${{secrets.TWINE_TEST_PASSWORD}}
-      GOOGLE_ANALYTICS_KEY: ${{secrets.GOOGLE_ANALYTICS_KEY}}
   call_u24_elements_release_alpine:
     if: >-
       github.event.workflow_run.conclusion == 'success' && github.repository_owner == 'datajoint' && !contains(github.event.workflow_run.head_branch, 'test')
@@ -27,4 +26,3 @@ jobs:
     secrets:
       TWINE_USERNAME: ${{secrets.TWINE_USERNAME}}
       TWINE_PASSWORD: ${{secrets.TWINE_PASSWORD}}
-      GOOGLE_ANALYTICS_KEY: ${{secrets.GOOGLE_ANALYTICS_KEY}}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,49 +3,57 @@
 Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
 [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) convention.
 
+## [0.1.7] - 2023 05-11
+
++ Fix - `.ipynb` dark mode output for all notebooks.
++ Update - CHANGELOG markdown from "-" to "+" for consistency with other
+  Elements.
++ Fix - Remove `GOOGLE_ANALYTICS_KEY` from `u24_element_release_call.yml`.
+
 ## [0.1.6] - 2023-04-28
 
-- Fix - `.ipynb` output in tutorials is not visible in dark mode.
++ Fix - `.ipynb` output in tutorials is not visible in dark mode.
 
 ## [0.1.5] - 2023-03-02
 
-- Add - `surgery` schema
-- Add - mkdocs documentation
-- Update - string typing for NWB export of Species
++ Add - `surgery` schema
++ Add - mkdocs documentation
++ Update - string typing for NWB export of Species
 
 ## [0.1.4] - 2022-08-30
 
-- Add - "subject_nickname" into Subject table
-- Update - rework "SubjectCull" table
++ Add - "subject_nickname" into Subject table
++ Update - rework "SubjectCull" table
 
 ## [0.1.3] - 2022-07-06
 
-- Update - Diagram links for PyPI README
++ Update - Diagram links for PyPI README
 
 ## [0.1.2] - 2022-06-27
 
-- Add - Code of Conduct
-- Update - pull subject from parent directory in nwb export
-- Update - for genotyping.BreedingPair part tables, projection from Subject
-  - genotyping.BreedingPair.Mother, change attribute to 'mother'
-  - genotyping.BreedingPair.Father, change attribute to 'father'
++ Add - Code of Conduct
++ Update - pull subject from parent directory in nwb export
++ Update - for genotyping.BreedingPair part tables, projection from Subject
+  + genotyping.BreedingPair.Mother, change attribute to 'mother'
+  + genotyping.BreedingPair.Father, change attribute to 'father'
 
 ## [0.1.1] - 2022-05-10
 
-- Add - NWB export
-- Update - Shorten subject primary key to varchar(8)
-- Add - Adopt black formatting into code base
++ Add - NWB export
++ Update - Shorten subject primary key to varchar(8)
++ Add - Adopt black formatting into code base
 
 ## [0.1.0b0] - 2021-05-07
 
-- Update - First beta release
++ Update - First beta release
 
 ## [0.1.0a1] - 2021-05-03
 
-- Add - GitHub Action release process
-- Add - `subject` schema
-- Add - `genotyping` schema
++ Add - GitHub Action release process
++ Add - `subject` schema
++ Add - `genotyping` schema
 
+[0.1.7]: https://github.com/datajoint/element-animal/releases/tag/0.1.7
 [0.1.6]: https://github.com/datajoint/element-animal/releases/tag/0.1.6
 [0.1.5]: https://github.com/datajoint/element-animal/releases/tag/0.1.5
 [0.1.4]: https://github.com/datajoint/element-animal/releases/tag/0.1.4

--- a/docs/src/.overrides/assets/stylesheets/extra.css
+++ b/docs/src/.overrides/assets/stylesheets/extra.css
@@ -92,6 +92,7 @@ html a[title="YouTube"].md-social__link svg {
     /* --md-footer-fg-color: var(--dj-white); */
 }
 
-[data-md-color-scheme="slate"] .jupyter-wrapper .Table Td {
+[data-md-color-scheme="slate"] td,
+th {
     color: var(--dj-black)
 }

--- a/element_animal/version.py
+++ b/element_animal/version.py
@@ -1,2 +1,2 @@
 """Package metadata."""
-__version__ = "0.1.6"
+__version__ = "0.1.7"


### PR DESCRIPTION
This PR fixes the outstanding dark mode issues from #38. Other fixes here include minor styling changes to the CHANGELOG for consistency with other elements and removing references to the `GOOGLE_ANALYTICS_KEY`. 

PR Summary: 

- [x] Updated dark mode fix
- [x] Remove GOOGLE_ANALYTICS_KEY reference for CI/CD
- [x] Update CHANGELOG
- [x] Update version.py 
- [ ] Push new tag after merging