### PR TITLE
Change subject ID from `varchar(8)` to `varchar(16)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
 [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) convention.
 
+## [0.1.9] - 2023-07-31
+
++ Update - Subject ID attribute from `varchar(8)` to `varchar(16)`
++ Fix - Small errors in docstrings
+
 ## [0.1.8] - 2023-06-20
 
 + Update - GitHub Actions workflows
@@ -58,6 +63,7 @@ Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
 + Add - `subject` schema
 + Add - `genotyping` schema
 
+[0.1.9]: https://github.com/datajoint/element-animal/releases/tag/0.1.9
 [0.1.8]: https://github.com/datajoint/element-animal/releases/tag/0.1.8
 [0.1.7]: https://github.com/datajoint/element-animal/releases/tag/0.1.7
 [0.1.6]: https://github.com/datajoint/element-animal/releases/tag/0.1.6

--- a/element_animal/subject.py
+++ b/element_animal/subject.py
@@ -146,15 +146,15 @@ class Subject(dj.Manual):
     """Animal subject information.
 
     Attributes:
-        subject ( varchar(8) ): Subject ID.
-        subject_nickname ( varchar(8) ): Subject nickname.
+        subject ( varchar(16) ): Subject ID.
+        subject_nickname ( varchar(64) ): Subject nickname.
         sex (enum): 'M', 'F', or 'U'; Male, Female, or Unknown.
         subject_birth_date (date): Birth date of the subject.
         subject_description ( varchar(1024) ): Description of the subject.
     """
 
     definition = """
-    subject                 : varchar(8)
+    subject                 : varchar(16)
     ---
     subject_nickname=''     : varchar(64)
     sex                     : enum('M', 'F', 'U')

--- a/element_animal/version.py
+++ b/element_animal/version.py
@@ -1,2 +1,2 @@
 """Package metadata."""
-__version__ = "0.1.8"
+__version__ = "0.1.9"


### PR DESCRIPTION
This update will allow for subject names > 8 characters and reduce the occurrence of the following error: `DataError: (1406, "Data too long for column 'subject' at row 1")`. 

The following changes have been / will be complete upon merging:

- [ ] Update attribute for subject ID.
- [ ] Update corresponding docstring.
- [ ] Address small error in subject nickname docstring.
- [ ] Update CHANGELOG.
- [ ] Update `version.py`.
- [ ] Release new version to PyPI.