### PR TITLE
Add injection schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
 ## [0.2.0] - 2023-08-23
 
 + Add - `injection` schema
++ Update - docstrings, `linking_module` within each `activate` function
 
 ## [0.1.8] - 2023-06-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
 [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) convention.
 
+## [0.2.0] - 2023-08-23
+
++ Add - `injection` schema
+
 ## [0.1.8] - 2023-06-20
 
 + Update - GitHub Actions workflows
@@ -58,6 +62,7 @@ Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
 + Add - `subject` schema
 + Add - `genotyping` schema
 
+[0.2.0]: https://github.com/datajoint/element-animal/releases/tag/0.2.0
 [0.1.8]: https://github.com/datajoint/element-animal/releases/tag/0.1.8
 [0.1.7]: https://github.com/datajoint/element-animal/releases/tag/0.1.7
 [0.1.6]: https://github.com/datajoint/element-animal/releases/tag/0.1.6

--- a/docs/src/concepts.md
+++ b/docs/src/concepts.md
@@ -56,6 +56,10 @@ There are three modules in `element-animal`:
 
 ![Surgery schema diagram](https://raw.githubusercontent.com/datajoint/element-animal/main/images/surgery_diagram.svg)
 
+### Injection Diagram
+
+![Injection schema diagram](https://raw.githubusercontent.com/datajoint/element-animal/main/images/injection_diagram.svg)
+
 ## `subject` schema ([API docs](https://datajoint.com/docs/elements/element-animal/api/element_animal/subject))
 
 - Although not required, most choose to connect the `Session` table to a `Subject` table.
@@ -93,3 +97,12 @@ There are three modules in `element-animal`:
 | Hemisphere          | Brain region hemisphere                                        |
 | ImplantationType    | Type of implantation                                           |
 | Implantation        | Implantation of a device                                       |
+
+### `injection` schema ([API docs](https://datajoint.com/docs/elements/element-animal/api/element_animal/injection))
+
+| Table               | Description                                                    |
+| ------------------- | -------------------------------------------------------------- |
+| VirusSerotype       | Virus serotype                                                 |
+| InjectionProtocol   | Injection device protocol                                      |
+| VirusName           | Full virus name                                                |
+| Injection           | Information about the virus injection                          |

--- a/element_animal/genotyping.py
+++ b/element_animal/genotyping.py
@@ -6,14 +6,15 @@ import datajoint as dj
 from . import subject
 
 schema = dj.schema()
+_linking_module = None
 
 
 def activate(
-    genotyping_schema_name,
-    subject_schema_name=None,
-    create_schema=True,
-    create_tables=True,
-    linking_module=None,
+    genotyping_schema_name: str,
+    subject_schema_name: str = None,
+    create_schema: bool = True,
+    create_tables: bool = True,
+    linking_module: str = None,
 ):
     """Activate this schema.
 
@@ -26,8 +27,8 @@ def activate(
                             database if it does not yet exist.
         create_tables (bool, optional): when True (default), create tables in the
                             database if they do not yet exist.
-        linking_module (bool, optional): a module name or a module containing the
-        required dependencies to activate the `subject` element:
+        linking_module (str): A module name or a module containing the required
+            dependencies to activate the `genotyping` module.
 
     Dependencies:
     Upstream tables:
@@ -56,7 +57,7 @@ def activate(
         genotyping_schema_name,
         create_schema=create_schema,
         create_tables=create_tables,
-        add_objects=linking_module.__dict__,
+        add_objects=_linking_module.__dict__,
     )
 
 

--- a/element_animal/genotyping.py
+++ b/element_animal/genotyping.py
@@ -14,7 +14,7 @@ def activate(
     subject_schema_name: str = None,
     create_schema: bool = True,
     create_tables: bool = True,
-    linking_module: str = None,
+    linking_module = None,
 ):
     """Activate this schema.
 

--- a/element_animal/genotyping.py
+++ b/element_animal/genotyping.py
@@ -14,7 +14,7 @@ def activate(
     subject_schema_name: str = None,
     create_schema: bool = True,
     create_tables: bool = True,
-    linking_module = None,
+    linking_module=None,
 ):
     """Activate this schema.
 

--- a/element_animal/injection.py
+++ b/element_animal/injection.py
@@ -1,0 +1,129 @@
+import importlib
+import inspect
+
+import datajoint as dj
+
+from . import surgery
+
+schema = dj.Schema()
+
+_linking_module = None
+
+
+def activate(
+    injection_schema_name: str,
+    surgery_schema_name: str = None,
+    *,
+    create_schema: bool = True,
+    create_tables: bool = True,
+    linking_module: bool = True,
+):
+    """Activate this schema.
+
+    Args:
+        schema_name (str): schema name on the database server to activate the
+                        `subject` element
+        create_schema (bool): when True (default), create schema in the
+                            database if it does not yet exist.
+        create_tables (bool): when True (default), create tables in the
+                            database if they do not yet exist.
+        linking_module (bool): a module name or a module containing the
+        required dependencies to activate the `subject` element:
+
+    Dependencies:
+    Upstream tables:
+        User: the who conducted a particular surgery/implantation
+    """
+
+    if isinstance(linking_module, str):
+        linking_module = importlib.import_module(linking_module)
+    assert inspect.ismodule(
+        linking_module
+    ), "The argument 'linking_module' must be a module's name or a module"
+
+    global _linking_module
+    _linking_module = linking_module
+
+    surgery.activate(
+        surgery_schema_name,
+        create_schema=create_schema,
+        create_tables=create_tables,
+        linking_module=linking_module,
+    )
+    schema.activate(
+        injection_schema_name,
+        create_schema=create_schema,
+        create_tables=create_tables,
+        add_objects=linking_module.__dict__,
+    )
+
+
+@schema
+class AAVSerotype(dj.Lookup):
+    definition = """
+    aav_serotype: varchar(10)
+    """
+    contents = zip(
+        [
+            "AAV1",
+            "AAV2",
+            "AAV4",
+            "AAV5",
+            "AAV6",
+            "AAV7",
+            "AAV8",
+            "AAV9",
+            "AAV2/1",
+            "AAV2/5",
+            "AAV2/9",
+            "AAVrg",
+            "AAV/DJ",
+            "pAAV",
+        ]
+    )
+
+
+@schema
+class MicroInjectionDevice(dj.Lookup):
+    definition = """
+    micro_injection_device: varchar(12)
+    """
+    contents = zip(
+        [
+            "Nanoject",
+            "Picospritzer",
+        ]
+    )
+
+
+@schema
+class InjectionProtocol(dj.Manual):
+    definition = """
+    -> MicroInjectionDevice
+    protocol_id         : int
+    ---
+    volume_per_pulse    : float
+    injection_rate      : float
+    interpulse_delay    : float
+    """
+
+
+@schema
+class VirusName(dj.Manual):
+    definition = """
+    virus_name: varchar(64)  # Full virus name. Ex: AAV1.CAG.Flex.ArchT.GFP. 
+    """
+
+
+@schema
+class Injection(dj.Manual):
+    definition = """
+    -> surgery.Implantation
+    -> VirusName
+    -> surgery.BrainRegion
+    ---
+    -> [nullable] AAVSerotype
+    -> [nullable] InjectionProtocol
+    titer           : varchar(16)
+    total_volume    : float
+    """

--- a/element_animal/injection.py
+++ b/element_animal/injection.py
@@ -44,11 +44,6 @@ def activate(
     global _linking_module
     _linking_module = linking_module
 
-    lab.activate(
-        lab_schema_name,
-        create_schema=create_schema,
-        create_tables=create_tables,
-    )
     surgery.activate(
         surgery_schema_name,
         create_schema=create_schema,

--- a/element_animal/injection.py
+++ b/element_animal/injection.py
@@ -16,7 +16,7 @@ def activate(
     *,
     create_schema: bool = True,
     create_tables: bool = True,
-    linking_module: str = None,
+    linking_module = None,
 ):
     """Activate this schema.
 

--- a/element_animal/injection.py
+++ b/element_animal/injection.py
@@ -16,7 +16,7 @@ def activate(
     *,
     create_schema: bool = True,
     create_tables: bool = True,
-    linking_module = None,
+    linking_module=None,
 ):
     """Activate this schema.
 

--- a/element_animal/injection.py
+++ b/element_animal/injection.py
@@ -129,7 +129,7 @@ class VirusName(dj.Manual):
     """
 
     definition = """
-    virus_name: varchar(64)  # Full virus name. Ex: AAV1.CAG.Flex.ArchT.GFP. 
+    virus_name: varchar(64)  # Full virus name. Ex: AAV1.CAG.Flex.ArchT.GFP.
     ---
     -> [nullable] VirusSerotype
     """
@@ -145,8 +145,7 @@ class Injection(dj.Manual):
         VirusName (foreign key): Primary key from VirusName.
         InjectionProtocol (foreign key): Primary key from InjectionProtocol.
         titer (str): Titer of injectate at the current injection site.
-        total_volume (float): Total volume injected at the current injection 
-        site.
+        total_volume (float): Total volume injected at the current injection site. 
         injection_comment (str): Comments about the virus injection. 
     """
 

--- a/element_animal/injection.py
+++ b/element_animal/injection.py
@@ -145,7 +145,8 @@ class Injection(dj.Manual):
         VirusName (foreign key): Primary key from VirusName.
         InjectionProtocol (foreign key): Primary key from InjectionProtocol.
         titer (str): Titer of injectate at the current injection site.
-        total_volume (float): Total volume injected at the current injection site.
+        total_volume (float): Total volume injected at the current injection 
+        site.
         injection_comment (str): Comments about the virus injection. 
     """
 

--- a/element_animal/injection.py
+++ b/element_animal/injection.py
@@ -59,9 +59,9 @@ def activate(
 
 
 @schema
-class AAVSerotype(dj.Lookup):
+class VirusSerotype(dj.Lookup):
     definition = """
-    aav_serotype: varchar(10)
+    virus_serotype: varchar(10)
     """
     contents = zip(
         [
@@ -99,9 +99,9 @@ class MicroInjectionDevice(dj.Lookup):
 @schema
 class InjectionProtocol(dj.Manual):
     definition = """
-    -> MicroInjectionDevice
     protocol_id         : int
     ---
+    -> MicroInjectionDevice
     volume_per_pulse    : float
     injection_rate      : float
     interpulse_delay    : float
@@ -112,6 +112,8 @@ class InjectionProtocol(dj.Manual):
 class VirusName(dj.Manual):
     definition = """
     virus_name: varchar(64)  # Full virus name. Ex: AAV1.CAG.Flex.ArchT.GFP. 
+    ---
+    -> VirusSerotype
     """
 
 
@@ -120,10 +122,9 @@ class Injection(dj.Manual):
     definition = """
     -> surgery.Implantation
     -> VirusName
-    -> surgery.BrainRegion
+    -> InjectionProtocol
     ---
-    -> [nullable] AAVSerotype
-    -> [nullable] InjectionProtocol
     titer           : varchar(16)
     total_volume    : float
+    injection_comment=''  : varchar(1024)
     """

--- a/element_animal/injection.py
+++ b/element_animal/injection.py
@@ -7,7 +7,6 @@ from element_lab import lab
 from . import surgery
 
 schema = dj.Schema()
-
 _linking_module = None
 
 
@@ -99,7 +98,7 @@ class VirusSerotype(dj.Lookup):
 @schema
 class InjectionProtocol(dj.Manual):
     """Injection device protocol.
-    
+
     Attributes:
         protocol_id (int): Unique protocol ID.
         lab.Device (foreign key): Primary key from lab.Device.
@@ -145,8 +144,8 @@ class Injection(dj.Manual):
         VirusName (foreign key): Primary key from VirusName.
         InjectionProtocol (foreign key): Primary key from InjectionProtocol.
         titer (str): Titer of injectate at the current injection site.
-        total_volume (float): Total volume injected at the current injection site. 
-        injection_comment (str): Comments about the virus injection. 
+        total_volume (float): Total volume injected at the current injection site.
+        injection_comment (str): Comments about the virus injection.
     """
 
     definition = """

--- a/element_animal/injection.py
+++ b/element_animal/injection.py
@@ -3,7 +3,6 @@ import inspect
 
 import datajoint as dj
 
-from element_lab import lab
 from . import surgery
 
 schema = dj.Schema()
@@ -17,7 +16,7 @@ def activate(
     *,
     create_schema: bool = True,
     create_tables: bool = True,
-    linking_module: bool = True,
+    linking_module: str = None,
 ):
     """Activate this schema.
 
@@ -28,12 +27,12 @@ def activate(
                             database if it does not yet exist.
         create_tables (bool): when True (default), create tables in the
                             database if they do not yet exist.
-        linking_module (bool): a module name or a module containing the
-        required dependencies to activate the `subject` element:
+        linking_module (str): A module name or a module containing the required
+            dependencies to activate the `injection` module.
 
     Dependencies:
     Upstream tables:
-        User: the who conducted a particular surgery/implantation
+        Device: table from `element-lab`.
     """
 
     if isinstance(linking_module, str):
@@ -54,13 +53,13 @@ def activate(
         surgery_schema_name,
         create_schema=create_schema,
         create_tables=create_tables,
-        linking_module=linking_module,
+        linking_module=_linking_module,
     )
     schema.activate(
         injection_schema_name,
         create_schema=create_schema,
         create_tables=create_tables,
-        add_objects=linking_module.__dict__,
+        add_objects=_linking_module.__dict__,
     )
 
 
@@ -111,7 +110,7 @@ class InjectionProtocol(dj.Manual):
     definition = """
     protocol_id         : int
     ---
-    -> lab.Device
+    -> Device
     volume_per_pulse    : float
     injection_rate      : float
     interpulse_delay    : float

--- a/element_animal/subject.py
+++ b/element_animal/subject.py
@@ -11,7 +11,7 @@ def activate(
     *,
     create_schema: bool = True,
     create_tables: bool = True,
-    linking_module: bool = True,
+    linking_module: str = None,
 ):
     """Activate this schema.
 
@@ -22,8 +22,8 @@ def activate(
                             database if it does not yet exist.
         create_tables (bool): when True (default), create tables in the
                             database if they do not yet exist.
-        linking_module (bool): a module name or a module containing the
-        required dependencies to activate the `subject` element:
+        linking_module (str): A module name or a module containing the required
+            dependencies to activate the `subject` module.
 
     Dependencies:
     Upstream tables:
@@ -49,7 +49,7 @@ def activate(
         schema_name,
         create_schema=create_schema,
         create_tables=create_tables,
-        add_objects=linking_module.__dict__,
+        add_objects=_linking_module.__dict__,
     )
 
 

--- a/element_animal/subject.py
+++ b/element_animal/subject.py
@@ -11,7 +11,7 @@ def activate(
     *,
     create_schema: bool = True,
     create_tables: bool = True,
-    linking_module = None,
+    linking_module=None,
 ):
     """Activate this schema.
 

--- a/element_animal/subject.py
+++ b/element_animal/subject.py
@@ -11,7 +11,7 @@ def activate(
     *,
     create_schema: bool = True,
     create_tables: bool = True,
-    linking_module: str = None,
+    linking_module = None,
 ):
     """Activate this schema.
 

--- a/element_animal/subject.py
+++ b/element_animal/subject.py
@@ -147,7 +147,7 @@ class Subject(dj.Manual):
 
     Attributes:
         subject ( varchar(8) ): Subject ID.
-        subject_nickname ( varchar(8) ): Subject nickname.
+        subject_nickname ( varchar(64) ): Subject nickname.
         sex (enum): 'M', 'F', or 'U'; Male, Female, or Unknown.
         subject_birth_date (date): Birth date of the subject.
         subject_description ( varchar(1024) ): Description of the subject.

--- a/element_animal/surgery.py
+++ b/element_animal/surgery.py
@@ -132,21 +132,15 @@ class Implantation(dj.Manual):
     """Implantation of a device
 
     Attributes:
-        Session (foreign key): Session primary key
-        location_id (int): ID of of brain location
-        ap ( float ): In mm, Anterior/posterior; Anterior Positive
-        ap_reference (projected attribute): Coordinate reference
-        ml ( float ): In mm, medial axis; Right Positive
-        ml_reference (projected attribute): Coordinate reference
-        dv ( float ): In mm, dorso-ventral axis. Ventral negative
-        dv_reference (projected attribute): Coordinate reference
-        theta ( float, nullable ): Elevation in degrees.
-            Rotation about ml-axis [0, 180] relative to z-axis
-        phi ( float, nullable ): Azimuth in degrees.
-            Rotations about dv-axis [0, 360] relative to x-axis
-        beta ( float, nullable ): Rotation about shank in degrees.
-            Rotation about the shank [-180, 180]. Clockwise is increasing.
-            0 is the probe-front facing anterior
+        Subject (foreign key): Subject primary key.
+        implant_date (datetime): ID of brain location.
+        ImplantationType (foreign key): ImplantationType primary key.
+        region_acronym ( projected attribute, varchar(32) ): Brain region
+        shorthand from BrainRegion.
+        hemisphere ( projected attribute, varchar(8) ): Brain region hemisphere
+        from Hemisphere.
+        user ( projected attribute, varchar(32) ): User who performed the surgery.
+        implant_comment ( varchar(1024) ): Comments about the implant.
     """
 
     definition = """
@@ -161,6 +155,22 @@ class Implantation(dj.Manual):
     """
 
     class Coordinate(dj.Part):
+        """Coordinates of the Implantation Device.
+
+        Attributes:
+            Implantation (foreign key): Primary keys from Implantation.
+            ap ( float ): In mm, Anterior/posterior; Anterior Positive.
+            ap_reference (projected attribute): Coordinate reference.
+            ml ( float ): In mm, medial axis; Right Positive.
+            ml_reference (projected attribute): Coordinate reference.
+            dv ( float ): In mm, dorso-ventral axis. Ventral negative.
+            dv_reference (projected attribute): Coordinate reference.
+            theta ( float, nullable ): Elevation in degrees. Rotation about ml-axis [0, 180] relative to z-axis.
+            phi ( float, nullable ): Azimuth in degrees. Rotations about dv-axis [0, 360] relative to x-axis.
+            beta ( float, nullable ): Rotation about shank in degrees. Rotation
+            about the shank [-180, 180]. Clockwise is increasing. 0 is the probe-front facing anterior.
+        """
+
         definition = """
         -> master
         ---

--- a/element_animal/surgery.py
+++ b/element_animal/surgery.py
@@ -16,7 +16,7 @@ def activate(
     *,
     create_schema: bool = True,
     create_tables: bool = True,
-    linking_module: str = None,
+    linking_module = None,
 ):
     """Activate this schema.
 

--- a/element_animal/surgery.py
+++ b/element_animal/surgery.py
@@ -16,7 +16,7 @@ def activate(
     *,
     create_schema: bool = True,
     create_tables: bool = True,
-    linking_module = None,
+    linking_module=None,
 ):
     """Activate this schema.
 

--- a/element_animal/surgery.py
+++ b/element_animal/surgery.py
@@ -16,7 +16,7 @@ def activate(
     *,
     create_schema: bool = True,
     create_tables: bool = True,
-    linking_module: bool = True,
+    linking_module: str = None,
 ):
     """Activate this schema.
 
@@ -27,8 +27,8 @@ def activate(
                             database if it does not yet exist.
         create_tables (bool): when True (default), create tables in the
                             database if they do not yet exist.
-        linking_module (bool): a module name or a module containing the
-        required dependencies to activate the `subject` element:
+        linking_module (str): A module name or a module containing the required
+            dependencies to activate the `surgery` module.
 
     Dependencies:
     Upstream tables:
@@ -54,7 +54,7 @@ def activate(
         surgery_schema_name,
         create_schema=create_schema,
         create_tables=create_tables,
-        add_objects=linking_module.__dict__,
+        add_objects=_linking_module.__dict__,
     )
 
 

--- a/element_animal/surgery.py
+++ b/element_animal/surgery.py
@@ -133,14 +133,14 @@ class Implantation(dj.Manual):
 
     Attributes:
         Subject (foreign key): Subject primary key.
-        implant_date (datetime): ID of brain location.
+        implant_date (datetime): Date and time of implantation surgery.
         ImplantationType (foreign key): ImplantationType primary key.
         region_acronym ( projected attribute, varchar(32) ): Brain region
         shorthand from BrainRegion.
         hemisphere ( projected attribute, varchar(8) ): Brain region hemisphere
         from Hemisphere.
         user ( projected attribute, varchar(32) ): User who performed the surgery.
-        implant_comment ( varchar(1024) ): Comments about the implant.
+        implant_comment ( varchar(1024), optional ): Comments about the implant.
     """
 
     definition = """

--- a/element_animal/version.py
+++ b/element_animal/version.py
@@ -1,2 +1,2 @@
 """Package metadata."""
-__version__ = "0.1.8"
+__version__ = "0.2.0"

--- a/images/injection_diagram.svg
+++ b/images/injection_diagram.svg
@@ -1,0 +1,187 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="668pt" height="256pt" viewBox="0.00 0.00 668.00 256.00">
+<g id="graph0" class="graph" transform="scale(1 1) rotate(0) translate(4 252)">
+<title>%3</title>
+<polygon fill="white" stroke="none" points="-4,4 -4,-252 664,-252 664,4 -4,4"/>
+<!-- 28 -->
+<g id="node1" class="node"><title>28</title>
+<ellipse fill="#ff8800" fill-opacity="0.501961" stroke="#ff8800" stroke-opacity="0.501961" cx="71" cy="-88.5" rx="2" ry="2"/>
+<text text-anchor="middle" x="71" y="-88.2" font-family="arial" font-size="1.00" fill="#ff8800">28</text>
+</g>
+<!-- surgery.Implantation.Coordinate -->
+<g id="node15" class="node"><title>surgery.Implantation.Coordinate</title>
+<g id="a_node15"><a xlink:title="→ surgery.Implantation------------------------------ap=null              → [nullable] surgery.CoordinateReference.proj(ap_ref=&quot;reference&quot;)ml=null              → [nullable] surgery.CoordinateReference.proj(ml_ref=&quot;reference&quot;)dv=null              → [nullable] surgery.CoordinateReference.proj(dv_ref=&quot;reference&quot;)theta=null           phi=null             beta=null            ">
+<polygon fill="none" stroke="none" points="263,-27 109,-27 109,-8 263,-8 263,-27"/>
+<text text-anchor="middle" x="186" y="-15" font-family="arial" font-size="10.00">surgery.Implantation.Coordinate</text>
+</a>
+</g>
+</g>
+<!-- 28&#45;&gt;surgery.Implantation.Coordinate -->
+<g id="edge1" class="edge"><title>28-&gt;surgery.Implantation.Coordinate</title>
+<path fill="none" stroke="#000000" stroke-width="0.75" stroke-dasharray="5,2" stroke-opacity="0.250980" d="M71.9037,-86.5169C74.4241,-83.8112 81.8184,-76.1163 89,-71 114.421,-52.8895 146.795,-36.5575 166.961,-27.0814"/>
+</g>
+<!-- 24 -->
+<g id="node2" class="node"><title>24</title>
+<ellipse fill="#ff8800" fill-opacity="0.501961" stroke="#ff8800" stroke-opacity="0.501961" cx="349" cy="-159.5" rx="2" ry="2"/>
+<text text-anchor="middle" x="349" y="-159.2" font-family="arial" font-size="1.00" fill="#ff8800">24</text>
+</g>
+<!-- surgery.Implantation -->
+<g id="node14" class="node"><title>surgery.Implantation</title>
+<g id="a_node14"><a xlink:title="→ subject.Subjectimplant_date         → surgery.ImplantationType→ surgery.BrainRegion.proj(target_region=&quot;region_acronym&quot;)→ surgery.Hemisphere.proj(target_hemisphere=&quot;hemisphere&quot;)------------------------------→ `kushalbakshi_`.`#user`.proj(surgeon=&quot;user&quot;)implant_comment=&quot;&quot;   ">
+<polygon fill="#00ff00" fill-opacity="0.188235" stroke="#00ff00" stroke-opacity="0.188235" points="290,-106 170,-106 170,-71 290,-71 290,-106"/>
+<text text-anchor="start" x="178" y="-86.4" font-family="arial" text-decoration="underline" font-size="12.00" fill="darkgreen">surgery.Implantation</text>
+</a>
+</g>
+</g>
+<!-- 24&#45;&gt;surgery.Implantation -->
+<g id="edge2" class="edge"><title>24-&gt;surgery.Implantation</title>
+<path fill="none" stroke="#000000" stroke-width="0.75" stroke-opacity="0.250980" d="M348.038,-157.518C345.357,-154.815 337.504,-147.126 330,-142 309.923,-128.286 285.833,-115.54 266.329,-106.042"/>
+</g>
+<!-- 29 -->
+<g id="node3" class="node"><title>29</title>
+<ellipse fill="#ff8800" fill-opacity="0.501961" stroke="#ff8800" stroke-opacity="0.501961" cx="107" cy="-88.5" rx="2" ry="2"/>
+<text text-anchor="middle" x="107" y="-88.2" font-family="arial" font-size="1.00" fill="#ff8800">29</text>
+</g>
+<!-- 29&#45;&gt;surgery.Implantation.Coordinate -->
+<g id="edge3" class="edge"><title>29-&gt;surgery.Implantation.Coordinate</title>
+<path fill="none" stroke="#000000" stroke-width="0.75" stroke-dasharray="5,2" stroke-opacity="0.250980" d="M107.966,-86.5949C110.645,-84.0885 118.408,-76.8559 125,-71 142.55,-55.411 163.336,-37.6727 175.553,-27.3197"/>
+</g>
+<!-- 25 -->
+<g id="node4" class="node"><title>25</title>
+<ellipse fill="#ff8800" fill-opacity="0.501961" stroke="#ff8800" stroke-opacity="0.501961" cx="169" cy="-159.5" rx="2" ry="2"/>
+<text text-anchor="middle" x="169" y="-159.2" font-family="arial" font-size="1.00" fill="#ff8800">25</text>
+</g>
+<!-- 25&#45;&gt;surgery.Implantation -->
+<g id="edge4" class="edge"><title>25-&gt;surgery.Implantation</title>
+<path fill="none" stroke="#000000" stroke-width="0.75" stroke-opacity="0.250980" d="M169.862,-157.525C174.728,-152.021 199.107,-124.445 215.292,-106.137"/>
+</g>
+<!-- 27 -->
+<g id="node5" class="node"><title>27</title>
+<ellipse fill="#ff8800" fill-opacity="0.501961" stroke="#ff8800" stroke-opacity="0.501961" cx="143" cy="-88.5" rx="2" ry="2"/>
+<text text-anchor="middle" x="143" y="-88.2" font-family="arial" font-size="1.00" fill="#ff8800">27</text>
+</g>
+<!-- 27&#45;&gt;surgery.Implantation.Coordinate -->
+<g id="edge5" class="edge"><title>27-&gt;surgery.Implantation.Coordinate</title>
+<path fill="none" stroke="#000000" stroke-width="0.75" stroke-dasharray="5,2" stroke-opacity="0.250980" d="M143.608,-86.5246C147.589,-80.1364 170.102,-44.0113 180.604,-27.1581"/>
+</g>
+<!-- injection.VirusSerotype -->
+<g id="node6" class="node"><title>injection.VirusSerotype</title>
+<g id="a_node6"><a xlink:title="virus_serotype       ">
+<polygon fill="#000000" fill-opacity="0.125490" stroke="none" points="493.5,-177 376.5,-177 376.5,-142 493.5,-142 493.5,-177"/>
+<text text-anchor="start" x="384.5" y="-158" font-family="arial" text-decoration="underline" font-size="10.00">injection.VirusSerotype</text>
+</a>
+</g>
+</g>
+<!-- injection.VirusName -->
+<g id="node11" class="node"><title>injection.VirusName</title>
+<g id="a_node11"><a xlink:title="virus_name           ------------------------------→ injection.VirusSerotype">
+<polygon fill="#00ff00" fill-opacity="0.188235" stroke="#00ff00" stroke-opacity="0.188235" points="493.5,-106 372.5,-106 372.5,-71 493.5,-71 493.5,-106"/>
+<text text-anchor="start" x="380.5" y="-86.4" font-family="arial" text-decoration="underline" font-size="12.00" fill="darkgreen">injection.VirusName</text>
+</a>
+</g>
+</g>
+<!-- injection.VirusSerotype&#45;&gt;injection.VirusName -->
+<g id="edge6" class="edge"><title>injection.VirusSerotype-&gt;injection.VirusName</title>
+<path fill="none" stroke="#000000" stroke-width="0.75" stroke-dasharray="5,2" stroke-opacity="0.250980" d="M434.516,-141.797C434.201,-130.949 433.793,-116.867 433.48,-106.049"/>
+</g>
+<!-- injection.MicroInjectionDevice -->
+<g id="node7" class="node"><title>injection.MicroInjectionDevice</title>
+<g id="a_node7"><a xlink:title="micro_injection_device ">
+<polygon fill="#000000" fill-opacity="0.125490" stroke="none" points="658,-177 514,-177 514,-142 658,-142 658,-177"/>
+<text text-anchor="start" x="522" y="-158" font-family="arial" text-decoration="underline" font-size="10.00">injection.MicroInjectionDevice</text>
+</a>
+</g>
+</g>
+<!-- injection.InjectionProtocol -->
+<g id="node12" class="node"><title>injection.InjectionProtocol</title>
+<g id="a_node12"><a xlink:title="protocol_id          ------------------------------→ injection.MicroInjectionDevicevolume_per_pulse     injection_rate       interpulse_delay     ">
+<polygon fill="#00ff00" fill-opacity="0.188235" stroke="#00ff00" stroke-opacity="0.188235" points="660,-106 512,-106 512,-71 660,-71 660,-106"/>
+<text text-anchor="start" x="520" y="-86.4" font-family="arial" text-decoration="underline" font-size="12.00" fill="darkgreen">injection.InjectionProtocol</text>
+</a>
+</g>
+</g>
+<!-- injection.MicroInjectionDevice&#45;&gt;injection.InjectionProtocol -->
+<g id="edge7" class="edge"><title>injection.MicroInjectionDevice-&gt;injection.InjectionProtocol</title>
+<path fill="none" stroke="#000000" stroke-width="0.75" stroke-dasharray="5,2" stroke-opacity="0.250980" d="M586,-141.797C586,-130.949 586,-116.867 586,-106.049"/>
+</g>
+<!-- surgery.Hemisphere -->
+<g id="node8" class="node"><title>surgery.Hemisphere</title>
+<g id="a_node8"><a xlink:title="hemisphere           ">
+<polygon fill="#000000" fill-opacity="0.125490" stroke="none" points="221,-248 117,-248 117,-213 221,-213 221,-248"/>
+<text text-anchor="start" x="125" y="-229" font-family="arial" text-decoration="underline" font-size="10.00">surgery.Hemisphere</text>
+</a>
+</g>
+</g>
+<!-- surgery.Hemisphere&#45;&gt;25 -->
+<g id="edge8" class="edge"><title>surgery.Hemisphere-&gt;25</title>
+<path fill="none" stroke="#000000" stroke-width="0.75" stroke-opacity="0.250980" d="M169,-212.797C169,-194.929 169,-168.29 169,-161.91"/>
+</g>
+<!-- surgery.BrainRegion -->
+<g id="node9" class="node"><title>surgery.BrainRegion</title>
+<g id="a_node9"><a xlink:title="region_acronym       ------------------------------region_name          ">
+<polygon fill="#00ff00" fill-opacity="0.188235" stroke="#00ff00" stroke-opacity="0.188235" points="410.5,-248 287.5,-248 287.5,-213 410.5,-213 410.5,-248"/>
+<text text-anchor="start" x="295.5" y="-228.4" font-family="arial" text-decoration="underline" font-size="12.00" fill="darkgreen">surgery.BrainRegion</text>
+</a>
+</g>
+</g>
+<!-- surgery.BrainRegion&#45;&gt;24 -->
+<g id="edge9" class="edge"><title>surgery.BrainRegion-&gt;24</title>
+<path fill="none" stroke="#000000" stroke-width="0.75" stroke-opacity="0.250980" d="M349,-212.797C349,-194.929 349,-168.29 349,-161.91"/>
+</g>
+<!-- surgery.ImplantationType -->
+<g id="node10" class="node"><title>surgery.ImplantationType</title>
+<g id="a_node10"><a xlink:title="implant_type         ------------------------------implant_description  ">
+<polygon fill="#000000" fill-opacity="0.125490" stroke="none" points="321.5,-177 196.5,-177 196.5,-142 321.5,-142 321.5,-177"/>
+<text text-anchor="start" x="204.5" y="-158" font-family="arial" text-decoration="underline" font-size="10.00">surgery.ImplantationType</text>
+</a>
+</g>
+</g>
+<!-- surgery.ImplantationType&#45;&gt;surgery.Implantation -->
+<g id="edge10" class="edge"><title>surgery.ImplantationType-&gt;surgery.Implantation</title>
+<path fill="none" stroke="#000000" stroke-width="0.75" stroke-opacity="0.250980" d="M251.98,-141.797C247.42,-130.949 241.502,-116.867 236.955,-106.049"/>
+</g>
+<!-- injection.Injection -->
+<g id="node16" class="node"><title>injection.Injection</title>
+<g id="a_node16"><a xlink:title="→ surgery.Implantation→ injection.VirusName→ injection.InjectionProtocol------------------------------titer                total_volume         injection_comment=&quot;&quot; ">
+<polygon fill="#00ff00" fill-opacity="0.188235" stroke="#00ff00" stroke-opacity="0.188235" points="485,-35 381,-35 381,-0 485,-0 485,-35"/>
+<text text-anchor="middle" x="433" y="-14.4" font-family="arial" font-size="12.00" fill="darkgreen">injection.Injection</text>
+</a>
+</g>
+</g>
+<!-- injection.VirusName&#45;&gt;injection.Injection -->
+<g id="edge11" class="edge"><title>injection.VirusName-&gt;injection.Injection</title>
+<path fill="none" stroke="#000000" stroke-width="0.75" stroke-opacity="0.250980" d="M433,-70.797C433,-59.9485 433,-45.8669 433,-35.0492"/>
+</g>
+<!-- injection.InjectionProtocol&#45;&gt;injection.Injection -->
+<g id="edge12" class="edge"><title>injection.InjectionProtocol-&gt;injection.Injection</title>
+<path fill="none" stroke="#000000" stroke-width="0.75" stroke-opacity="0.250980" d="M549.353,-70.9728C525.218,-60.0885 493.741,-45.893 469.613,-35.0118"/>
+</g>
+<!-- surgery.CoordinateReference -->
+<g id="node13" class="node"><title>surgery.CoordinateReference</title>
+<g id="a_node13"><a xlink:title="reference            ">
+<polygon fill="#000000" fill-opacity="0.125490" stroke="none" points="142,-177 0,-177 0,-142 142,-142 142,-177"/>
+<text text-anchor="start" x="8" y="-158" font-family="arial" text-decoration="underline" font-size="10.00">surgery.CoordinateReference</text>
+</a>
+</g>
+</g>
+<!-- surgery.CoordinateReference&#45;&gt;28 -->
+<g id="edge14" class="edge"><title>surgery.CoordinateReference-&gt;28</title>
+<path fill="none" stroke="#000000" stroke-width="0.75" stroke-dasharray="5,2" stroke-opacity="0.250980" d="M71,-141.797C71,-123.929 71,-97.2901 71,-90.9096"/>
+</g>
+<!-- surgery.CoordinateReference&#45;&gt;29 -->
+<g id="edge15" class="edge"><title>surgery.CoordinateReference-&gt;29</title>
+<path fill="none" stroke="#000000" stroke-width="0.75" stroke-dasharray="5,2" stroke-opacity="0.250980" d="M79.7146,-141.797C89.0371,-123.929 102.936,-97.2901 106.265,-90.9096"/>
+</g>
+<!-- surgery.CoordinateReference&#45;&gt;27 -->
+<g id="edge13" class="edge"><title>surgery.CoordinateReference-&gt;27</title>
+<path fill="none" stroke="#000000" stroke-width="0.75" stroke-dasharray="5,2" stroke-opacity="0.250980" d="M88.4292,-141.797C107.074,-123.929 134.871,-97.2901 141.529,-90.9096"/>
+</g>
+<!-- surgery.Implantation&#45;&gt;surgery.Implantation.Coordinate -->
+<g id="edge16" class="edge"><title>surgery.Implantation-&gt;surgery.Implantation.Coordinate</title>
+<path fill="none" stroke="#000000" stroke-width="2" stroke-opacity="0.250980" d="M219.349,-70.797C210.6,-57.0768 198.553,-38.1854 191.589,-27.2652"/>
+</g>
+<!-- surgery.Implantation&#45;&gt;injection.Injection -->
+<g id="edge17" class="edge"><title>surgery.Implantation-&gt;injection.Injection</title>
+<path fill="none" stroke="#000000" stroke-width="0.75" stroke-opacity="0.250980" d="M278.624,-70.9728C310.645,-60.0885 352.409,-45.893 384.422,-35.0118"/>
+</g>
+</g>
+</svg>

--- a/images/injection_diagram.svg
+++ b/images/injection_diagram.svg
@@ -1,187 +1,187 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="668pt" height="256pt" viewBox="0.00 0.00 668.00 256.00">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="647pt" height="256pt" viewBox="0.00 0.00 647.00 256.00">
 <g id="graph0" class="graph" transform="scale(1 1) rotate(0) translate(4 252)">
 <title>%3</title>
-<polygon fill="white" stroke="none" points="-4,4 -4,-252 664,-252 664,4 -4,4"/>
-<!-- 28 -->
-<g id="node1" class="node"><title>28</title>
-<ellipse fill="#ff8800" fill-opacity="0.501961" stroke="#ff8800" stroke-opacity="0.501961" cx="71" cy="-88.5" rx="2" ry="2"/>
-<text text-anchor="middle" x="71" y="-88.2" font-family="arial" font-size="1.00" fill="#ff8800">28</text>
-</g>
-<!-- surgery.Implantation.Coordinate -->
-<g id="node15" class="node"><title>surgery.Implantation.Coordinate</title>
-<g id="a_node15"><a xlink:title="→ surgery.Implantation------------------------------ap=null              → [nullable] surgery.CoordinateReference.proj(ap_ref=&quot;reference&quot;)ml=null              → [nullable] surgery.CoordinateReference.proj(ml_ref=&quot;reference&quot;)dv=null              → [nullable] surgery.CoordinateReference.proj(dv_ref=&quot;reference&quot;)theta=null           phi=null             beta=null            ">
-<polygon fill="none" stroke="none" points="263,-27 109,-27 109,-8 263,-8 263,-27"/>
-<text text-anchor="middle" x="186" y="-15" font-family="arial" font-size="10.00">surgery.Implantation.Coordinate</text>
-</a>
-</g>
-</g>
-<!-- 28&#45;&gt;surgery.Implantation.Coordinate -->
-<g id="edge1" class="edge"><title>28-&gt;surgery.Implantation.Coordinate</title>
-<path fill="none" stroke="#000000" stroke-width="0.75" stroke-dasharray="5,2" stroke-opacity="0.250980" d="M71.9037,-86.5169C74.4241,-83.8112 81.8184,-76.1163 89,-71 114.421,-52.8895 146.795,-36.5575 166.961,-27.0814"/>
-</g>
-<!-- 24 -->
-<g id="node2" class="node"><title>24</title>
-<ellipse fill="#ff8800" fill-opacity="0.501961" stroke="#ff8800" stroke-opacity="0.501961" cx="349" cy="-159.5" rx="2" ry="2"/>
-<text text-anchor="middle" x="349" y="-159.2" font-family="arial" font-size="1.00" fill="#ff8800">24</text>
+<polygon fill="white" stroke="none" points="-4,4 -4,-252 643,-252 643,4 -4,4"/>
+<!-- 19 -->
+<g id="node1" class="node"><title>19</title>
+<ellipse fill="#ff8800" fill-opacity="0.501961" stroke="#ff8800" stroke-opacity="0.501961" cx="313" cy="-159.5" rx="2" ry="2"/>
+<text text-anchor="middle" x="313" y="-159.2" font-family="arial" font-size="1.00" fill="#ff8800">19</text>
 </g>
 <!-- surgery.Implantation -->
-<g id="node14" class="node"><title>surgery.Implantation</title>
-<g id="a_node14"><a xlink:title="→ subject.Subjectimplant_date         → surgery.ImplantationType→ surgery.BrainRegion.proj(target_region=&quot;region_acronym&quot;)→ surgery.Hemisphere.proj(target_hemisphere=&quot;hemisphere&quot;)------------------------------→ `kushalbakshi_`.`#user`.proj(surgeon=&quot;user&quot;)implant_comment=&quot;&quot;   ">
+<g id="node8" class="node"><title>surgery.Implantation</title>
+<g id="a_node8"><a xlink:title="→ subject.Subjectimplant_date         → surgery.ImplantationType→ surgery.BrainRegion.proj(target_region=&quot;region_acronym&quot;)→ surgery.Hemisphere.proj(target_hemisphere=&quot;hemisphere&quot;)------------------------------→ `kushalbakshi_`.`#user`.proj(surgeon=&quot;user&quot;)implant_comment=&quot;&quot;   ">
 <polygon fill="#00ff00" fill-opacity="0.188235" stroke="#00ff00" stroke-opacity="0.188235" points="290,-106 170,-106 170,-71 290,-71 290,-106"/>
 <text text-anchor="start" x="178" y="-86.4" font-family="arial" text-decoration="underline" font-size="12.00" fill="darkgreen">surgery.Implantation</text>
 </a>
 </g>
 </g>
-<!-- 24&#45;&gt;surgery.Implantation -->
-<g id="edge2" class="edge"><title>24-&gt;surgery.Implantation</title>
-<path fill="none" stroke="#000000" stroke-width="0.75" stroke-opacity="0.250980" d="M348.038,-157.518C345.357,-154.815 337.504,-147.126 330,-142 309.923,-128.286 285.833,-115.54 266.329,-106.042"/>
+<!-- 19&#45;&gt;surgery.Implantation -->
+<g id="edge1" class="edge"><title>19-&gt;surgery.Implantation</title>
+<path fill="none" stroke="#000000" stroke-width="0.75" stroke-opacity="0.250980" d="M311.979,-157.595C309.147,-155.091 300.944,-147.861 294,-142 279.614,-129.857 263.192,-116.394 250.585,-106.142"/>
 </g>
-<!-- 29 -->
-<g id="node3" class="node"><title>29</title>
+<!-- 23 -->
+<g id="node2" class="node"><title>23</title>
+<ellipse fill="#ff8800" fill-opacity="0.501961" stroke="#ff8800" stroke-opacity="0.501961" cx="71" cy="-88.5" rx="2" ry="2"/>
+<text text-anchor="middle" x="71" y="-88.2" font-family="arial" font-size="1.00" fill="#ff8800">23</text>
+</g>
+<!-- surgery.Implantation.Coordinate -->
+<g id="node9" class="node"><title>surgery.Implantation.Coordinate</title>
+<g id="a_node9"><a xlink:title="→ surgery.Implantation------------------------------ap=null              → [nullable] surgery.CoordinateReference.proj(ap_ref=&quot;reference&quot;)ml=null              → [nullable] surgery.CoordinateReference.proj(ml_ref=&quot;reference&quot;)dv=null              → [nullable] surgery.CoordinateReference.proj(dv_ref=&quot;reference&quot;)theta=null           phi=null             beta=null            ">
+<polygon fill="none" stroke="none" points="263,-27 109,-27 109,-8 263,-8 263,-27"/>
+<text text-anchor="middle" x="186" y="-15" font-family="arial" font-size="10.00">surgery.Implantation.Coordinate</text>
+</a>
+</g>
+</g>
+<!-- 23&#45;&gt;surgery.Implantation.Coordinate -->
+<g id="edge2" class="edge"><title>23-&gt;surgery.Implantation.Coordinate</title>
+<path fill="none" stroke="#000000" stroke-width="0.75" stroke-dasharray="5,2" stroke-opacity="0.250980" d="M71.9037,-86.5169C74.4241,-83.8112 81.8184,-76.1163 89,-71 114.421,-52.8895 146.795,-36.5575 166.961,-27.0814"/>
+</g>
+<!-- 18 -->
+<g id="node3" class="node"><title>18</title>
+<ellipse fill="#ff8800" fill-opacity="0.501961" stroke="#ff8800" stroke-opacity="0.501961" cx="349" cy="-159.5" rx="2" ry="2"/>
+<text text-anchor="middle" x="349" y="-159.2" font-family="arial" font-size="1.00" fill="#ff8800">18</text>
+</g>
+<!-- 18&#45;&gt;surgery.Implantation -->
+<g id="edge3" class="edge"><title>18-&gt;surgery.Implantation</title>
+<path fill="none" stroke="#000000" stroke-width="0.75" stroke-opacity="0.250980" d="M348.101,-157.511C345.592,-154.789 338.224,-147.056 331,-142 311.086,-128.062 286.992,-115.398 267.332,-106.001"/>
+</g>
+<!-- 21 -->
+<g id="node4" class="node"><title>21</title>
 <ellipse fill="#ff8800" fill-opacity="0.501961" stroke="#ff8800" stroke-opacity="0.501961" cx="107" cy="-88.5" rx="2" ry="2"/>
-<text text-anchor="middle" x="107" y="-88.2" font-family="arial" font-size="1.00" fill="#ff8800">29</text>
+<text text-anchor="middle" x="107" y="-88.2" font-family="arial" font-size="1.00" fill="#ff8800">21</text>
 </g>
-<!-- 29&#45;&gt;surgery.Implantation.Coordinate -->
-<g id="edge3" class="edge"><title>29-&gt;surgery.Implantation.Coordinate</title>
+<!-- 21&#45;&gt;surgery.Implantation.Coordinate -->
+<g id="edge4" class="edge"><title>21-&gt;surgery.Implantation.Coordinate</title>
 <path fill="none" stroke="#000000" stroke-width="0.75" stroke-dasharray="5,2" stroke-opacity="0.250980" d="M107.966,-86.5949C110.645,-84.0885 118.408,-76.8559 125,-71 142.55,-55.411 163.336,-37.6727 175.553,-27.3197"/>
 </g>
-<!-- 25 -->
-<g id="node4" class="node"><title>25</title>
-<ellipse fill="#ff8800" fill-opacity="0.501961" stroke="#ff8800" stroke-opacity="0.501961" cx="169" cy="-159.5" rx="2" ry="2"/>
-<text text-anchor="middle" x="169" y="-159.2" font-family="arial" font-size="1.00" fill="#ff8800">25</text>
-</g>
-<!-- 25&#45;&gt;surgery.Implantation -->
-<g id="edge4" class="edge"><title>25-&gt;surgery.Implantation</title>
-<path fill="none" stroke="#000000" stroke-width="0.75" stroke-opacity="0.250980" d="M169.862,-157.525C174.728,-152.021 199.107,-124.445 215.292,-106.137"/>
-</g>
-<!-- 27 -->
-<g id="node5" class="node"><title>27</title>
+<!-- 22 -->
+<g id="node5" class="node"><title>22</title>
 <ellipse fill="#ff8800" fill-opacity="0.501961" stroke="#ff8800" stroke-opacity="0.501961" cx="143" cy="-88.5" rx="2" ry="2"/>
-<text text-anchor="middle" x="143" y="-88.2" font-family="arial" font-size="1.00" fill="#ff8800">27</text>
+<text text-anchor="middle" x="143" y="-88.2" font-family="arial" font-size="1.00" fill="#ff8800">22</text>
 </g>
-<!-- 27&#45;&gt;surgery.Implantation.Coordinate -->
-<g id="edge5" class="edge"><title>27-&gt;surgery.Implantation.Coordinate</title>
+<!-- 22&#45;&gt;surgery.Implantation.Coordinate -->
+<g id="edge5" class="edge"><title>22-&gt;surgery.Implantation.Coordinate</title>
 <path fill="none" stroke="#000000" stroke-width="0.75" stroke-dasharray="5,2" stroke-opacity="0.250980" d="M143.608,-86.5246C147.589,-80.1364 170.102,-44.0113 180.604,-27.1581"/>
 </g>
+<!-- lab.Device -->
+<g id="node6" class="node"><title>lab.Device</title>
+<g id="a_node6"><a xlink:title="device               ------------------------------modality             description=null     ">
+<polygon fill="#000000" fill-opacity="0.125490" stroke="none" points="595.5,-177 534.5,-177 534.5,-142 595.5,-142 595.5,-177"/>
+<text text-anchor="start" x="542.5" y="-158" font-family="arial" text-decoration="underline" font-size="10.00">lab.Device</text>
+</a>
+</g>
+</g>
+<!-- injection.InjectionProtocol -->
+<g id="node13" class="node"><title>injection.InjectionProtocol</title>
+<g id="a_node13"><a xlink:title="protocol_id          ------------------------------→ lab.Devicevolume_per_pulse     injection_rate       interpulse_delay     ">
+<polygon fill="#00ff00" fill-opacity="0.188235" stroke="#00ff00" stroke-opacity="0.188235" points="639,-106 491,-106 491,-71 639,-71 639,-106"/>
+<text text-anchor="start" x="499" y="-86.4" font-family="arial" text-decoration="underline" font-size="12.00" fill="darkgreen">injection.InjectionProtocol</text>
+</a>
+</g>
+</g>
+<!-- lab.Device&#45;&gt;injection.InjectionProtocol -->
+<g id="edge6" class="edge"><title>lab.Device-&gt;injection.InjectionProtocol</title>
+<path fill="none" stroke="#000000" stroke-width="0.75" stroke-dasharray="5,2" stroke-opacity="0.250980" d="M565,-141.797C565,-130.949 565,-116.867 565,-106.049"/>
+</g>
+<!-- injection.VirusName -->
+<g id="node7" class="node"><title>injection.VirusName</title>
+<g id="a_node7"><a xlink:title="virus_name           ------------------------------→ [nullable] injection.VirusSerotype">
+<polygon fill="#00ff00" fill-opacity="0.188235" stroke="#00ff00" stroke-opacity="0.188235" points="472.5,-106 351.5,-106 351.5,-71 472.5,-71 472.5,-106"/>
+<text text-anchor="start" x="359.5" y="-86.4" font-family="arial" text-decoration="underline" font-size="12.00" fill="darkgreen">injection.VirusName</text>
+</a>
+</g>
+</g>
+<!-- injection.Injection -->
+<g id="node14" class="node"><title>injection.Injection</title>
+<g id="a_node14"><a xlink:title="→ surgery.Implantation→ injection.VirusName→ injection.InjectionProtocol------------------------------titer                total_volume         injection_comment=&quot;&quot; ">
+<polygon fill="#00ff00" fill-opacity="0.188235" stroke="#00ff00" stroke-opacity="0.188235" points="464,-35 360,-35 360,-0 464,-0 464,-35"/>
+<text text-anchor="middle" x="412" y="-14.4" font-family="arial" font-size="12.00" fill="darkgreen">injection.Injection</text>
+</a>
+</g>
+</g>
+<!-- injection.VirusName&#45;&gt;injection.Injection -->
+<g id="edge7" class="edge"><title>injection.VirusName-&gt;injection.Injection</title>
+<path fill="none" stroke="#000000" stroke-width="0.75" stroke-opacity="0.250980" d="M412,-70.797C412,-59.9485 412,-45.8669 412,-35.0492"/>
+</g>
+<!-- surgery.Implantation&#45;&gt;surgery.Implantation.Coordinate -->
+<g id="edge8" class="edge"><title>surgery.Implantation-&gt;surgery.Implantation.Coordinate</title>
+<path fill="none" stroke="#000000" stroke-width="2" stroke-opacity="0.250980" d="M219.349,-70.797C210.6,-57.0768 198.553,-38.1854 191.589,-27.2652"/>
+</g>
+<!-- surgery.Implantation&#45;&gt;injection.Injection -->
+<g id="edge9" class="edge"><title>surgery.Implantation-&gt;injection.Injection</title>
+<path fill="none" stroke="#000000" stroke-width="0.75" stroke-opacity="0.250980" d="M273.594,-70.9728C302.303,-60.0885 339.746,-45.893 368.447,-35.0118"/>
+</g>
+<!-- surgery.Hemisphere -->
+<g id="node10" class="node"><title>surgery.Hemisphere</title>
+<g id="a_node10"><a xlink:title="hemisphere           ">
+<polygon fill="#000000" fill-opacity="0.125490" stroke="none" points="317,-248 213,-248 213,-213 317,-213 317,-248"/>
+<text text-anchor="start" x="221" y="-229" font-family="arial" text-decoration="underline" font-size="10.00">surgery.Hemisphere</text>
+</a>
+</g>
+</g>
+<!-- surgery.Hemisphere&#45;&gt;19 -->
+<g id="edge10" class="edge"><title>surgery.Hemisphere-&gt;19</title>
+<path fill="none" stroke="#000000" stroke-width="0.75" stroke-opacity="0.250980" d="M276.619,-212.797C289.049,-194.929 307.581,-168.29 312.019,-161.91"/>
+</g>
+<!-- surgery.BrainRegion -->
+<g id="node11" class="node"><title>surgery.BrainRegion</title>
+<g id="a_node11"><a xlink:title="region_acronym       ------------------------------region_name          ">
+<polygon fill="#00ff00" fill-opacity="0.188235" stroke="#00ff00" stroke-opacity="0.188235" points="458.5,-248 335.5,-248 335.5,-213 458.5,-213 458.5,-248"/>
+<text text-anchor="start" x="343.5" y="-228.4" font-family="arial" text-decoration="underline" font-size="12.00" fill="darkgreen">surgery.BrainRegion</text>
+</a>
+</g>
+</g>
+<!-- surgery.BrainRegion&#45;&gt;18 -->
+<g id="edge11" class="edge"><title>surgery.BrainRegion-&gt;18</title>
+<path fill="none" stroke="#000000" stroke-width="0.75" stroke-opacity="0.250980" d="M385.381,-212.797C372.951,-194.929 354.419,-168.29 349.981,-161.91"/>
+</g>
 <!-- injection.VirusSerotype -->
-<g id="node6" class="node"><title>injection.VirusSerotype</title>
-<g id="a_node6"><a xlink:title="virus_serotype       ">
+<g id="node12" class="node"><title>injection.VirusSerotype</title>
+<g id="a_node12"><a xlink:title="virus_serotype       ">
 <polygon fill="#000000" fill-opacity="0.125490" stroke="none" points="493.5,-177 376.5,-177 376.5,-142 493.5,-142 493.5,-177"/>
 <text text-anchor="start" x="384.5" y="-158" font-family="arial" text-decoration="underline" font-size="10.00">injection.VirusSerotype</text>
 </a>
 </g>
 </g>
-<!-- injection.VirusName -->
-<g id="node11" class="node"><title>injection.VirusName</title>
-<g id="a_node11"><a xlink:title="virus_name           ------------------------------→ injection.VirusSerotype">
-<polygon fill="#00ff00" fill-opacity="0.188235" stroke="#00ff00" stroke-opacity="0.188235" points="493.5,-106 372.5,-106 372.5,-71 493.5,-71 493.5,-106"/>
-<text text-anchor="start" x="380.5" y="-86.4" font-family="arial" text-decoration="underline" font-size="12.00" fill="darkgreen">injection.VirusName</text>
-</a>
-</g>
-</g>
 <!-- injection.VirusSerotype&#45;&gt;injection.VirusName -->
-<g id="edge6" class="edge"><title>injection.VirusSerotype-&gt;injection.VirusName</title>
-<path fill="none" stroke="#000000" stroke-width="0.75" stroke-dasharray="5,2" stroke-opacity="0.250980" d="M434.516,-141.797C434.201,-130.949 433.793,-116.867 433.48,-106.049"/>
+<g id="edge12" class="edge"><title>injection.VirusSerotype-&gt;injection.VirusName</title>
+<path fill="none" stroke="#000000" stroke-width="0.75" stroke-dasharray="5,2" stroke-opacity="0.250980" d="M429.432,-141.797C425.816,-130.949 421.122,-116.867 417.516,-106.049"/>
 </g>
-<!-- injection.MicroInjectionDevice -->
-<g id="node7" class="node"><title>injection.MicroInjectionDevice</title>
-<g id="a_node7"><a xlink:title="micro_injection_device ">
-<polygon fill="#000000" fill-opacity="0.125490" stroke="none" points="658,-177 514,-177 514,-142 658,-142 658,-177"/>
-<text text-anchor="start" x="522" y="-158" font-family="arial" text-decoration="underline" font-size="10.00">injection.MicroInjectionDevice</text>
-</a>
-</g>
-</g>
-<!-- injection.InjectionProtocol -->
-<g id="node12" class="node"><title>injection.InjectionProtocol</title>
-<g id="a_node12"><a xlink:title="protocol_id          ------------------------------→ injection.MicroInjectionDevicevolume_per_pulse     injection_rate       interpulse_delay     ">
-<polygon fill="#00ff00" fill-opacity="0.188235" stroke="#00ff00" stroke-opacity="0.188235" points="660,-106 512,-106 512,-71 660,-71 660,-106"/>
-<text text-anchor="start" x="520" y="-86.4" font-family="arial" text-decoration="underline" font-size="12.00" fill="darkgreen">injection.InjectionProtocol</text>
-</a>
-</g>
-</g>
-<!-- injection.MicroInjectionDevice&#45;&gt;injection.InjectionProtocol -->
-<g id="edge7" class="edge"><title>injection.MicroInjectionDevice-&gt;injection.InjectionProtocol</title>
-<path fill="none" stroke="#000000" stroke-width="0.75" stroke-dasharray="5,2" stroke-opacity="0.250980" d="M586,-141.797C586,-130.949 586,-116.867 586,-106.049"/>
-</g>
-<!-- surgery.Hemisphere -->
-<g id="node8" class="node"><title>surgery.Hemisphere</title>
-<g id="a_node8"><a xlink:title="hemisphere           ">
-<polygon fill="#000000" fill-opacity="0.125490" stroke="none" points="221,-248 117,-248 117,-213 221,-213 221,-248"/>
-<text text-anchor="start" x="125" y="-229" font-family="arial" text-decoration="underline" font-size="10.00">surgery.Hemisphere</text>
-</a>
-</g>
-</g>
-<!-- surgery.Hemisphere&#45;&gt;25 -->
-<g id="edge8" class="edge"><title>surgery.Hemisphere-&gt;25</title>
-<path fill="none" stroke="#000000" stroke-width="0.75" stroke-opacity="0.250980" d="M169,-212.797C169,-194.929 169,-168.29 169,-161.91"/>
-</g>
-<!-- surgery.BrainRegion -->
-<g id="node9" class="node"><title>surgery.BrainRegion</title>
-<g id="a_node9"><a xlink:title="region_acronym       ------------------------------region_name          ">
-<polygon fill="#00ff00" fill-opacity="0.188235" stroke="#00ff00" stroke-opacity="0.188235" points="410.5,-248 287.5,-248 287.5,-213 410.5,-213 410.5,-248"/>
-<text text-anchor="start" x="295.5" y="-228.4" font-family="arial" text-decoration="underline" font-size="12.00" fill="darkgreen">surgery.BrainRegion</text>
-</a>
-</g>
-</g>
-<!-- surgery.BrainRegion&#45;&gt;24 -->
-<g id="edge9" class="edge"><title>surgery.BrainRegion-&gt;24</title>
-<path fill="none" stroke="#000000" stroke-width="0.75" stroke-opacity="0.250980" d="M349,-212.797C349,-194.929 349,-168.29 349,-161.91"/>
+<!-- injection.InjectionProtocol&#45;&gt;injection.Injection -->
+<g id="edge13" class="edge"><title>injection.InjectionProtocol-&gt;injection.Injection</title>
+<path fill="none" stroke="#000000" stroke-width="0.75" stroke-opacity="0.250980" d="M528.353,-70.9728C504.218,-60.0885 472.741,-45.893 448.613,-35.0118"/>
 </g>
 <!-- surgery.ImplantationType -->
-<g id="node10" class="node"><title>surgery.ImplantationType</title>
-<g id="a_node10"><a xlink:title="implant_type         ------------------------------implant_description  ">
-<polygon fill="#000000" fill-opacity="0.125490" stroke="none" points="321.5,-177 196.5,-177 196.5,-142 321.5,-142 321.5,-177"/>
-<text text-anchor="start" x="204.5" y="-158" font-family="arial" text-decoration="underline" font-size="10.00">surgery.ImplantationType</text>
+<g id="node15" class="node"><title>surgery.ImplantationType</title>
+<g id="a_node15"><a xlink:title="implant_type         ------------------------------implant_description  ">
+<polygon fill="#000000" fill-opacity="0.125490" stroke="none" points="285.5,-177 160.5,-177 160.5,-142 285.5,-142 285.5,-177"/>
+<text text-anchor="start" x="168.5" y="-158" font-family="arial" text-decoration="underline" font-size="10.00">surgery.ImplantationType</text>
 </a>
 </g>
 </g>
 <!-- surgery.ImplantationType&#45;&gt;surgery.Implantation -->
-<g id="edge10" class="edge"><title>surgery.ImplantationType-&gt;surgery.Implantation</title>
-<path fill="none" stroke="#000000" stroke-width="0.75" stroke-opacity="0.250980" d="M251.98,-141.797C247.42,-130.949 241.502,-116.867 236.955,-106.049"/>
-</g>
-<!-- injection.Injection -->
-<g id="node16" class="node"><title>injection.Injection</title>
-<g id="a_node16"><a xlink:title="→ surgery.Implantation→ injection.VirusName→ injection.InjectionProtocol------------------------------titer                total_volume         injection_comment=&quot;&quot; ">
-<polygon fill="#00ff00" fill-opacity="0.188235" stroke="#00ff00" stroke-opacity="0.188235" points="485,-35 381,-35 381,-0 485,-0 485,-35"/>
-<text text-anchor="middle" x="433" y="-14.4" font-family="arial" font-size="12.00" fill="darkgreen">injection.Injection</text>
-</a>
-</g>
-</g>
-<!-- injection.VirusName&#45;&gt;injection.Injection -->
-<g id="edge11" class="edge"><title>injection.VirusName-&gt;injection.Injection</title>
-<path fill="none" stroke="#000000" stroke-width="0.75" stroke-opacity="0.250980" d="M433,-70.797C433,-59.9485 433,-45.8669 433,-35.0492"/>
-</g>
-<!-- injection.InjectionProtocol&#45;&gt;injection.Injection -->
-<g id="edge12" class="edge"><title>injection.InjectionProtocol-&gt;injection.Injection</title>
-<path fill="none" stroke="#000000" stroke-width="0.75" stroke-opacity="0.250980" d="M549.353,-70.9728C525.218,-60.0885 493.741,-45.893 469.613,-35.0118"/>
+<g id="edge14" class="edge"><title>surgery.ImplantationType-&gt;surgery.Implantation</title>
+<path fill="none" stroke="#000000" stroke-width="0.75" stroke-opacity="0.250980" d="M224.695,-141.797C225.795,-130.949 227.224,-116.867 228.321,-106.049"/>
 </g>
 <!-- surgery.CoordinateReference -->
-<g id="node13" class="node"><title>surgery.CoordinateReference</title>
-<g id="a_node13"><a xlink:title="reference            ">
+<g id="node16" class="node"><title>surgery.CoordinateReference</title>
+<g id="a_node16"><a xlink:title="reference            ">
 <polygon fill="#000000" fill-opacity="0.125490" stroke="none" points="142,-177 0,-177 0,-142 142,-142 142,-177"/>
 <text text-anchor="start" x="8" y="-158" font-family="arial" text-decoration="underline" font-size="10.00">surgery.CoordinateReference</text>
 </a>
 </g>
 </g>
-<!-- surgery.CoordinateReference&#45;&gt;28 -->
-<g id="edge14" class="edge"><title>surgery.CoordinateReference-&gt;28</title>
+<!-- surgery.CoordinateReference&#45;&gt;23 -->
+<g id="edge17" class="edge"><title>surgery.CoordinateReference-&gt;23</title>
 <path fill="none" stroke="#000000" stroke-width="0.75" stroke-dasharray="5,2" stroke-opacity="0.250980" d="M71,-141.797C71,-123.929 71,-97.2901 71,-90.9096"/>
 </g>
-<!-- surgery.CoordinateReference&#45;&gt;29 -->
-<g id="edge15" class="edge"><title>surgery.CoordinateReference-&gt;29</title>
+<!-- surgery.CoordinateReference&#45;&gt;21 -->
+<g id="edge15" class="edge"><title>surgery.CoordinateReference-&gt;21</title>
 <path fill="none" stroke="#000000" stroke-width="0.75" stroke-dasharray="5,2" stroke-opacity="0.250980" d="M79.7146,-141.797C89.0371,-123.929 102.936,-97.2901 106.265,-90.9096"/>
 </g>
-<!-- surgery.CoordinateReference&#45;&gt;27 -->
-<g id="edge13" class="edge"><title>surgery.CoordinateReference-&gt;27</title>
+<!-- surgery.CoordinateReference&#45;&gt;22 -->
+<g id="edge16" class="edge"><title>surgery.CoordinateReference-&gt;22</title>
 <path fill="none" stroke="#000000" stroke-width="0.75" stroke-dasharray="5,2" stroke-opacity="0.250980" d="M88.4292,-141.797C107.074,-123.929 134.871,-97.2901 141.529,-90.9096"/>
-</g>
-<!-- surgery.Implantation&#45;&gt;surgery.Implantation.Coordinate -->
-<g id="edge16" class="edge"><title>surgery.Implantation-&gt;surgery.Implantation.Coordinate</title>
-<path fill="none" stroke="#000000" stroke-width="2" stroke-opacity="0.250980" d="M219.349,-70.797C210.6,-57.0768 198.553,-38.1854 191.589,-27.2652"/>
-</g>
-<!-- surgery.Implantation&#45;&gt;injection.Injection -->
-<g id="edge17" class="edge"><title>surgery.Implantation-&gt;injection.Injection</title>
-<path fill="none" stroke="#000000" stroke-width="0.75" stroke-opacity="0.250980" d="M278.624,-70.9728C310.645,-60.0885 352.409,-45.893 384.422,-35.0118"/>
 </g>
 </g>
 </svg>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 datajoint>=0.13
+element-lab
 pynwb>=1.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 datajoint>=0.13
-element-lab>=0.3.0
 pynwb>=1.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 datajoint>=0.13
-element-lab
+element-lab>=0.3.0
 pynwb>=1.4.0


### PR DESCRIPTION
This PR adds injection schema - tables related to viral injections (AAV, RSV, etc.) in the brain. In the current design, the injection schema contains tables with foreign keys to tables in the surgery schema, requiring the surgery module to be activated first. 

Before merging, the following will need to be addressed and resolved: 

- [x] Currently, the surgery module contains a table for `Implantation` which refers to an implantation surgery. Since a viral injection can be an independent surgery from an implant, a table redesign is likely necessary. A suggested redesign of the surgery module could take the form of: adding a Lookup table `SurgeryType` with options for `Implant`, `ViralInjection`, `Implant + ViralInjection`, and a downstream `Surgery` table containing the `SurgeryType` table as one of its attributes. 
- [x] Add docstrings to new tables.
- [x] Add / update documentation for the new tables and any table redesign.
- [x] Apply Black formatting
- [x] Update `version.py`
- [x] Update CHANGELOG