### PR TITLE
Add `Species` part table to `Subject`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
 [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) convention.
 
+## [0.2.0] - 2023-09-28
+
++ Add `Species` part table to `subject.py` 
+
 ## [0.1.8] - 2023-06-20
 
 + Update - GitHub Actions workflows
@@ -58,6 +62,7 @@ Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
 + Add - `subject` schema
 + Add - `genotyping` schema
 
+[0.2.0]: https://github.com/datajoint/element-animal/releases/tag/0.2.0
 [0.1.8]: https://github.com/datajoint/element-animal/releases/tag/0.1.8
 [0.1.7]: https://github.com/datajoint/element-animal/releases/tag/0.1.7
 [0.1.6]: https://github.com/datajoint/element-animal/releases/tag/0.1.6

--- a/element_animal/subject.py
+++ b/element_animal/subject.py
@@ -162,6 +162,20 @@ class Subject(dj.Manual):
     subject_description=''  : varchar(1024)
     """
 
+    class Species(dj.Part):
+        """Subject species as Latin binomial or NCBI taxonomic identifier.
+
+        Attributes:
+            Subject (foreign key): Primary key from Subject.
+            species (str): Subject species as Latin binomial or NCBI taxonomic identifier.
+        """
+        
+        definition = """
+        -> master
+        ---
+        species     : varchar(32)
+        """
+
     class Protocol(dj.Part):
         """Protocol under which this subject animal is used.
 

--- a/element_animal/subject.py
+++ b/element_animal/subject.py
@@ -169,7 +169,7 @@ class Subject(dj.Manual):
             Subject (foreign key): Primary key from Subject.
             species (str): Subject species as Latin binomial or NCBI taxonomic identifier.
         """
-        
+
         definition = """
         -> master
         ---

--- a/element_animal/version.py
+++ b/element_animal/version.py
@@ -1,2 +1,2 @@
 """Package metadata."""
-__version__ = "0.1.8"
+__version__ = "0.2.0"

--- a/images/subject_diagram.svg
+++ b/images/subject_diagram.svg
@@ -1,215 +1,198 @@
-<svg height="114pt" viewBox="0.00 0.00 1459.50 114.00" width="1460pt" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-<g class="graph" id="graph0" transform="scale(1 1) rotate(0) translate(4 110)">
-<polygon fill="white" points="-4,4 -4,-110 1455.5,-110 1455.5,4 -4,4" stroke="transparent"/>
-<!-- subject.Line -->
-<g class="node" id="node1">
-<title>subject.Line</title>
-<g id="a_node1"><a xlink:title="line                 ------------------------------line_description=&quot;&quot;  target_phenotype=&quot;&quot;  is_active            ">
-<polygon fill="#000000" fill-opacity="0.125490" points="82.5,-106 13.5,-106 13.5,-71 82.5,-71 82.5,-106" stroke="transparent"/>
-<text font-family="arial" font-size="10.00" text-anchor="start" text-decoration="underline" x="21.5" y="-87">subject.Line</text>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="1413pt" height="185pt" viewBox="0.00 0.00 1413.00 185.00">
+<g id="graph0" class="graph" transform="scale(1 1) rotate(0) translate(4 181)">
+<title>%3</title>
+<polygon fill="white" stroke="none" points="-4,4 -4,-181 1409,-181 1409,4 -4,4"/>
+<!-- subject.Subject.Source -->
+<g id="node1" class="node"><title>subject.Subject.Source</title>
+<g id="a_node1"><a xlink:title="→ subject.Subject------------------------------→ lab.Source">
+<polygon fill="none" stroke="none" points="525.5,-98 407.5,-98 407.5,-79 525.5,-79 525.5,-98"/>
+<text text-anchor="middle" x="466.5" y="-86" font-family="arial" font-size="10.00">subject.Subject.Source</text>
+</a>
+</g>
+</g>
+<!-- subject.Subject.User -->
+<g id="node2" class="node"><title>subject.Subject.User</title>
+<g id="a_node2"><a xlink:title="→ subject.Subject→ User">
+<polygon fill="none" stroke="none" points="651,-98 544,-98 544,-79 651,-79 651,-98"/>
+<text text-anchor="middle" x="597.5" y="-86" font-family="arial" font-size="10.00">subject.Subject.User</text>
 </a>
 </g>
 </g>
 <!-- subject.Line.Allele -->
-<g class="node" id="node9">
-<title>subject.Line.Allele</title>
-<g id="a_node9"><a xlink:title="→ subject.Line→ subject.Allele">
-<polygon fill="transparent" points="96,-27 0,-27 0,-8 96,-8 96,-27" stroke="transparent"/>
-<text font-family="arial" font-size="10.00" text-anchor="middle" x="48" y="-15">subject.Line.Allele</text>
+<g id="node3" class="node"><title>subject.Line.Allele</title>
+<g id="a_node3"><a xlink:title="→ subject.Line→ subject.Allele">
+<polygon fill="none" stroke="none" points="1277.5,-98 1181.5,-98 1181.5,-79 1277.5,-79 1277.5,-98"/>
+<text text-anchor="middle" x="1229.5" y="-86" font-family="arial" font-size="10.00">subject.Line.Allele</text>
 </a>
 </g>
 </g>
-<!-- subject.Line&#45;&gt;subject.Line.Allele -->
-<g class="edge" id="edge1">
-<title>subject.Line-&gt;subject.Line.Allele</title>
-<path d="M48,-70.8C48,-57.08 48,-38.19 48,-27.27" fill="none" stroke="#000000" stroke-opacity="0.250980" stroke-width="0.75"/>
-</g>
-<!-- subject.Subject.Line -->
-<g class="node" id="node11">
-<title>subject.Subject.Line</title>
-<g id="a_node11"><a xlink:title="→ subject.Subject------------------------------→ subject.Line">
-<polygon fill="transparent" points="346.5,-27 241.5,-27 241.5,-8 346.5,-8 346.5,-27" stroke="transparent"/>
-<text font-family="arial" font-size="10.00" text-anchor="middle" x="294" y="-15">subject.Subject.Line</text>
+<!-- subject.Subject.Species -->
+<g id="node4" class="node"><title>subject.Subject.Species</title>
+<g id="a_node4"><a xlink:title="→ subject.Subject------------------------------species              ">
+<polygon fill="none" stroke="none" points="791.5,-98 669.5,-98 669.5,-79 791.5,-79 791.5,-98"/>
+<text text-anchor="middle" x="730.5" y="-86" font-family="arial" font-size="10.00">subject.Subject.Species</text>
 </a>
 </g>
-</g>
-<!-- subject.Line&#45;&gt;subject.Subject.Line -->
-<g class="edge" id="edge2">
-<title>subject.Line-&gt;subject.Subject.Line</title>
-<path d="M82.72,-77.76C130.93,-64.24 217.38,-39.99 263.33,-27.1" fill="none" stroke="#000000" stroke-dasharray="5,2" stroke-opacity="0.250980" stroke-width="0.75"/>
-</g>
-<!-- subject.Allele.Source -->
-<g class="node" id="node2">
-<title>subject.Allele.Source</title>
-<g id="a_node2"><a xlink:title="→ subject.Allele------------------------------→ `lab`.`#source`source_identifier=&quot;&quot; source_url=&quot;&quot;        expression_data_url=&quot;&quot; ">
-<polygon fill="transparent" points="223.5,-27 114.5,-27 114.5,-8 223.5,-8 223.5,-27" stroke="transparent"/>
-<text font-family="arial" font-size="10.00" text-anchor="middle" x="169" y="-15">subject.Allele.Source</text>
-</a>
-</g>
-</g>
-<!-- subject.Subject.Source -->
-<g class="node" id="node3">
-<title>subject.Subject.Source</title>
-<g id="a_node3"><a xlink:title="→ subject.Subject------------------------------→ `lab`.`#source`">
-<polygon fill="transparent" points="993,-27 875,-27 875,-8 993,-8 993,-27" stroke="transparent"/>
-<text font-family="arial" font-size="10.00" text-anchor="middle" x="934" y="-15">subject.Subject.Source</text>
-</a>
-</g>
-</g>
-<!-- subject.SubjectCullMethod -->
-<g class="node" id="node4">
-<title>subject.SubjectCullMethod</title>
-<g id="a_node4"><a xlink:title="→ subject.Subject------------------------------cull_method          ">
-<polygon fill="#00ff00" fill-opacity="0.188235" points="1171,-35 1011,-35 1011,0 1171,0 1171,-35" stroke="#00ff00" stroke-opacity="0.188235"/>
-<text fill="darkgreen" font-family="arial" font-size="12.00" text-anchor="middle" x="1091" y="-14.4">subject.SubjectCullMethod</text>
-</a>
-</g>
-</g>
-<!-- subject.Subject -->
-<g class="node" id="node5">
-<title>subject.Subject</title>
-<g id="a_node5"><a xlink:title="subject              ------------------------------sex                  subject_birth_date   subject_description=&quot;&quot; ">
-<polygon fill="#00ff00" fill-opacity="0.188235" points="854,-106 756,-106 756,-71 854,-71 854,-106" stroke="#00ff00" stroke-opacity="0.188235"/>
-<text fill="darkgreen" font-family="arial" font-size="12.00" text-anchor="start" text-decoration="underline" x="764" y="-86.4">subject.Subject</text>
-</a>
-</g>
-</g>
-<!-- subject.Subject&#45;&gt;subject.Subject.Source -->
-<g class="edge" id="edge3">
-<title>subject.Subject-&gt;subject.Subject.Source</title>
-<path d="M835.9,-70.97C861.69,-57.18 897.42,-38.06 917.88,-27.12" fill="none" stroke="#000000" stroke-opacity="0.250980" stroke-width="2"/>
-</g>
-<!-- subject.Subject&#45;&gt;subject.SubjectCullMethod -->
-<g class="edge" id="edge4">
-<title>subject.Subject-&gt;subject.SubjectCullMethod</title>
-<path d="M854.17,-75.64C900.56,-64.45 970.55,-47.56 1022.43,-35.04" fill="none" stroke="#000000" stroke-opacity="0.250980" stroke-width="2"/>
-</g>
-<!-- subject.Subject.Strain -->
-<g class="node" id="node8">
-<title>subject.Subject.Strain</title>
-<g id="a_node8"><a xlink:title="→ subject.Subject------------------------------→ subject.Strain">
-<polygon fill="transparent" points="1451.5,-27 1338.5,-27 1338.5,-8 1451.5,-8 1451.5,-27" stroke="transparent"/>
-<text font-family="arial" font-size="10.00" text-anchor="middle" x="1395" y="-15">subject.Subject.Strain</text>
-</a>
-</g>
-</g>
-<!-- subject.Subject&#45;&gt;subject.Subject.Strain -->
-<g class="edge" id="edge5">
-<title>subject.Subject-&gt;subject.Subject.Strain</title>
-<path d="M854.19,-85.03C947.54,-79.8 1156.56,-65.51 1330,-35 1341.58,-32.96 1354.14,-29.96 1365.11,-27.08" fill="none" stroke="#000000" stroke-opacity="0.250980" stroke-width="2"/>
 </g>
 <!-- subject.SubjectDeath -->
-<g class="node" id="node10">
-<title>subject.SubjectDeath</title>
-<g id="a_node10"><a xlink:title="→ subject.Subject------------------------------death_date           ">
-<polygon fill="#00ff00" fill-opacity="0.188235" points="1320.5,-35 1189.5,-35 1189.5,0 1320.5,0 1320.5,-35" stroke="#00ff00" stroke-opacity="0.188235"/>
-<text fill="darkgreen" font-family="arial" font-size="12.00" text-anchor="middle" x="1255" y="-14.4">subject.SubjectDeath</text>
+<g id="node5" class="node"><title>subject.SubjectDeath</title>
+<g id="a_node5"><a xlink:title="→ subject.Subject------------------------------death_date           ">
+<polygon fill="#00ff00" fill-opacity="0.188235" stroke="#00ff00" stroke-opacity="0.188235" points="127,-106 -7.10543e-015,-106 -7.10543e-015,-71 127,-71 127,-106"/>
+<text text-anchor="middle" x="63.5" y="-85.4" font-family="arial" font-size="12.00" fill="darkgreen">subject.SubjectDeath</text>
 </a>
 </g>
 </g>
-<!-- subject.Subject&#45;&gt;subject.SubjectDeath -->
-<g class="edge" id="edge6">
-<title>subject.Subject-&gt;subject.SubjectDeath</title>
-<path d="M854.03,-81.86C925.84,-73.33 1063.7,-55.9 1180,-35 1183.02,-34.46 1186.1,-33.88 1189.21,-33.28" fill="none" stroke="#000000" stroke-opacity="0.250980" stroke-width="2"/>
-</g>
-<!-- subject.Subject&#45;&gt;subject.Subject.Line -->
-<g class="edge" id="edge7">
-<title>subject.Subject-&gt;subject.Subject.Line</title>
-<path d="M755.69,-84.15C672.51,-77.96 499.24,-62.76 355,-35 344.12,-32.91 332.33,-29.9 322.04,-27.02" fill="none" stroke="#000000" stroke-opacity="0.250980" stroke-width="2"/>
-</g>
-<!-- subject.Subject.Protocol -->
-<g class="node" id="node12">
-<title>subject.Subject.Protocol</title>
-<g id="a_node12"><a xlink:title="→ subject.Subject→ `lab`.`#protocol`">
-<polygon fill="transparent" points="608.5,-27 485.5,-27 485.5,-8 608.5,-8 608.5,-27" stroke="transparent"/>
-<text font-family="arial" font-size="10.00" text-anchor="middle" x="547" y="-15">subject.Subject.Protocol</text>
+<!-- subject.SubjectCull -->
+<g id="node16" class="node"><title>subject.SubjectCull</title>
+<g id="a_node16"><a xlink:title="→ subject.SubjectDeath------------------------------cull_method=&quot;&quot;       cull_reason=&quot;&quot;       cull_notes=&quot;&quot;        ">
+<polygon fill="#00ff00" fill-opacity="0.188235" stroke="#00ff00" stroke-opacity="0.188235" points="121,-35 6,-35 6,-0 121,-0 121,-35"/>
+<text text-anchor="middle" x="63.5" y="-14.4" font-family="arial" font-size="12.00" fill="darkgreen">subject.SubjectCull</text>
 </a>
 </g>
 </g>
-<!-- subject.Subject&#45;&gt;subject.Subject.Protocol -->
-<g class="edge" id="edge8">
-<title>subject.Subject-&gt;subject.Subject.Protocol</title>
-<path d="M755.86,-74.36C703.82,-60.44 623.17,-38.87 578.86,-27.02" fill="none" stroke="#000000" stroke-opacity="0.250980" stroke-width="0.75"/>
-</g>
-<!-- subject.Zygosity -->
-<g class="node" id="node13">
-<title>subject.Zygosity</title>
-<g id="a_node13"><a xlink:title="→ subject.Subject→ subject.Allele------------------------------zygosity             ">
-<polygon fill="#00ff00" fill-opacity="0.188235" points="467.5,-35 364.5,-35 364.5,0 467.5,0 467.5,-35" stroke="#00ff00" stroke-opacity="0.188235"/>
-<text fill="darkgreen" font-family="arial" font-size="12.00" text-anchor="middle" x="416" y="-14.4">subject.Zygosity</text>
-</a>
-</g>
-</g>
-<!-- subject.Subject&#45;&gt;subject.Zygosity -->
-<g class="edge" id="edge9">
-<title>subject.Subject-&gt;subject.Zygosity</title>
-<path d="M755.91,-81.39C691.34,-72.95 574.5,-56.34 476,-35 473.25,-34.41 470.45,-33.76 467.62,-33.08" fill="none" stroke="#000000" stroke-opacity="0.250980" stroke-width="0.75"/>
-</g>
-<!-- subject.Subject.User -->
-<g class="node" id="node14">
-<title>subject.Subject.User</title>
-<g id="a_node14"><a xlink:title="→ subject.Subject→ `lab`.`#user`">
-<polygon fill="transparent" points="735,-27 627,-27 627,-8 735,-8 735,-27" stroke="transparent"/>
-<text font-family="arial" font-size="10.00" text-anchor="middle" x="681" y="-15">subject.Subject.User</text>
-</a>
-</g>
-</g>
-<!-- subject.Subject&#45;&gt;subject.Subject.User -->
-<g class="edge" id="edge10">
-<title>subject.Subject-&gt;subject.Subject.User</title>
-<path d="M775.3,-70.97C750.51,-57.18 716.16,-38.06 696.49,-27.12" fill="none" stroke="#000000" stroke-opacity="0.250980" stroke-width="0.75"/>
-</g>
-<!-- subject.Subject.Lab -->
-<g class="node" id="node15">
-<title>subject.Subject.Lab</title>
-<g id="a_node15"><a xlink:title="→ subject.Subject→ `lab`.`#lab`------------------------------subject_alias=&quot;&quot;     ">
-<polygon fill="transparent" points="856.5,-27 753.5,-27 753.5,-8 856.5,-8 856.5,-27" stroke="transparent"/>
-<text font-family="arial" font-size="10.00" text-anchor="middle" x="805" y="-15">subject.Subject.Lab</text>
-</a>
-</g>
-</g>
-<!-- subject.Subject&#45;&gt;subject.Subject.Lab -->
-<g class="edge" id="edge11">
-<title>subject.Subject-&gt;subject.Subject.Lab</title>
-<path d="M805,-70.8C805,-57.08 805,-38.19 805,-27.27" fill="none" stroke="#000000" stroke-opacity="0.250980" stroke-width="0.75"/>
-</g>
-<!-- subject.Allele -->
-<g class="node" id="node6">
-<title>subject.Allele</title>
-<g id="a_node6"><a xlink:title="allele               ------------------------------allele_standard_name=&quot;&quot; ">
-<polygon fill="#000000" fill-opacity="0.125490" points="206.5,-106 131.5,-106 131.5,-71 206.5,-71 206.5,-106" stroke="transparent"/>
-<text font-family="arial" font-size="10.00" text-anchor="start" text-decoration="underline" x="139.5" y="-87">subject.Allele</text>
-</a>
-</g>
-</g>
-<!-- subject.Allele&#45;&gt;subject.Allele.Source -->
-<g class="edge" id="edge12">
-<title>subject.Allele-&gt;subject.Allele.Source</title>
-<path d="M169,-70.8C169,-57.08 169,-38.19 169,-27.27" fill="none" stroke="#000000" stroke-opacity="0.250980" stroke-width="2"/>
-</g>
-<!-- subject.Allele&#45;&gt;subject.Line.Allele -->
-<g class="edge" id="edge13">
-<title>subject.Allele-&gt;subject.Line.Allele</title>
-<path d="M140.02,-70.97C115.83,-57.18 82.31,-38.06 63.12,-27.12" fill="none" stroke="#000000" stroke-opacity="0.250980" stroke-width="0.75"/>
-</g>
-<!-- subject.Allele&#45;&gt;subject.Zygosity -->
-<g class="edge" id="edge14">
-<title>subject.Allele-&gt;subject.Zygosity</title>
-<path d="M206.51,-77.02C248.62,-65.26 317.2,-46.1 364.35,-32.93" fill="none" stroke="#000000" stroke-opacity="0.250980" stroke-width="0.75"/>
+<!-- subject.SubjectDeath&#45;&gt;subject.SubjectCull -->
+<g id="edge1" class="edge"><title>subject.SubjectDeath-&gt;subject.SubjectCull</title>
+<path fill="none" stroke="#000000" stroke-width="2" stroke-opacity="0.250980" d="M63.5,-70.797C63.5,-59.9485 63.5,-45.8669 63.5,-35.0492"/>
 </g>
 <!-- subject.Strain -->
-<g class="node" id="node7">
-<title>subject.Strain</title>
-<g id="a_node7"><a xlink:title="strain               ------------------------------strain_standard_name strain_desc=&quot;&quot;       ">
-<polygon fill="#000000" fill-opacity="0.125490" points="1433.5,-106 1356.5,-106 1356.5,-71 1433.5,-71 1433.5,-106" stroke="transparent"/>
-<text font-family="arial" font-size="10.00" text-anchor="start" text-decoration="underline" x="1364.5" y="-87">subject.Strain</text>
+<g id="node6" class="node"><title>subject.Strain</title>
+<g id="a_node6"><a xlink:title="strain               ------------------------------strain_standard_name strain_desc=&quot;&quot;       ">
+<polygon fill="#000000" fill-opacity="0.125490" stroke="none" points="905,-177 828,-177 828,-142 905,-142 905,-177"/>
+<text text-anchor="start" x="836" y="-158" font-family="arial" text-decoration="underline" font-size="10.00">subject.Strain</text>
+</a>
+</g>
+</g>
+<!-- subject.Subject.Strain -->
+<g id="node10" class="node"><title>subject.Subject.Strain</title>
+<g id="a_node10"><a xlink:title="→ subject.Subject------------------------------→ subject.Strain">
+<polygon fill="none" stroke="none" points="923,-98 810,-98 810,-79 923,-79 923,-98"/>
+<text text-anchor="middle" x="866.5" y="-86" font-family="arial" font-size="10.00">subject.Subject.Strain</text>
 </a>
 </g>
 </g>
 <!-- subject.Strain&#45;&gt;subject.Subject.Strain -->
-<g class="edge" id="edge15">
-<title>subject.Strain-&gt;subject.Subject.Strain</title>
-<path d="M1395,-70.8C1395,-57.08 1395,-38.19 1395,-27.27" fill="none" stroke="#000000" stroke-dasharray="5,2" stroke-opacity="0.250980" stroke-width="0.75"/>
+<g id="edge2" class="edge"><title>subject.Strain-&gt;subject.Subject.Strain</title>
+<path fill="none" stroke="#000000" stroke-width="0.75" stroke-dasharray="5,2" stroke-opacity="0.250980" d="M866.5,-141.797C866.5,-128.077 866.5,-109.185 866.5,-98.2652"/>
+</g>
+<!-- subject.Line -->
+<g id="node7" class="node"><title>subject.Line</title>
+<g id="a_node7"><a xlink:title="line                 ------------------------------species=&quot;&quot;           line_description=&quot;&quot;  target_phenotype=&quot;&quot;  is_active            ">
+<polygon fill="#000000" fill-opacity="0.125490" stroke="none" points="1264,-177 1195,-177 1195,-142 1264,-142 1264,-177"/>
+<text text-anchor="start" x="1203" y="-158" font-family="arial" text-decoration="underline" font-size="10.00">subject.Line</text>
+</a>
+</g>
+</g>
+<!-- subject.Line&#45;&gt;subject.Line.Allele -->
+<g id="edge3" class="edge"><title>subject.Line-&gt;subject.Line.Allele</title>
+<path fill="none" stroke="#000000" stroke-width="0.75" stroke-opacity="0.250980" d="M1229.5,-141.797C1229.5,-128.077 1229.5,-109.185 1229.5,-98.2652"/>
+</g>
+<!-- subject.Subject.Line -->
+<g id="node14" class="node"><title>subject.Subject.Line</title>
+<g id="a_node14"><a xlink:title="→ subject.Subject------------------------------→ subject.Line">
+<polygon fill="none" stroke="none" points="1046,-98 941,-98 941,-79 1046,-79 1046,-98"/>
+<text text-anchor="middle" x="993.5" y="-86" font-family="arial" font-size="10.00">subject.Subject.Line</text>
+</a>
+</g>
+</g>
+<!-- subject.Line&#45;&gt;subject.Subject.Line -->
+<g id="edge4" class="edge"><title>subject.Line-&gt;subject.Subject.Line</title>
+<path fill="none" stroke="#000000" stroke-width="0.75" stroke-dasharray="5,2" stroke-opacity="0.250980" d="M1194.93,-148.393C1148.33,-134.768 1066.18,-110.749 1022.58,-98.0024"/>
+</g>
+<!-- subject.Subject.Lab -->
+<g id="node8" class="node"><title>subject.Subject.Lab</title>
+<g id="a_node8"><a xlink:title="→ subject.Subject→ lab.Lab------------------------------subject_alias=&quot;&quot;     ">
+<polygon fill="none" stroke="none" points="248,-98 145,-98 145,-79 248,-79 248,-98"/>
+<text text-anchor="middle" x="196.5" y="-86" font-family="arial" font-size="10.00">subject.Subject.Lab</text>
+</a>
+</g>
+</g>
+<!-- subject.Zygosity -->
+<g id="node9" class="node"><title>subject.Zygosity</title>
+<g id="a_node9"><a xlink:title="→ subject.Subject→ subject.Allele------------------------------zygosity             ">
+<polygon fill="#00ff00" fill-opacity="0.188235" stroke="#00ff00" stroke-opacity="0.188235" points="1163,-106 1064,-106 1064,-71 1163,-71 1163,-106"/>
+<text text-anchor="middle" x="1113.5" y="-85.4" font-family="arial" font-size="12.00" fill="darkgreen">subject.Zygosity</text>
+</a>
+</g>
+</g>
+<!-- subject.Allele.Source -->
+<g id="node11" class="node"><title>subject.Allele.Source</title>
+<g id="a_node11"><a xlink:title="→ subject.Allele------------------------------→ lab.Sourcesource_identifier=&quot;&quot; source_url=&quot;&quot;        expression_data_url=&quot;&quot; ">
+<polygon fill="none" stroke="none" points="1405,-98 1296,-98 1296,-79 1405,-79 1405,-98"/>
+<text text-anchor="middle" x="1350.5" y="-86" font-family="arial" font-size="10.00">subject.Allele.Source</text>
+</a>
+</g>
+</g>
+<!-- subject.Subject.Protocol -->
+<g id="node12" class="node"><title>subject.Subject.Protocol</title>
+<g id="a_node12"><a xlink:title="→ subject.Subject→ lab.Protocol">
+<polygon fill="none" stroke="none" points="389,-98 266,-98 266,-79 389,-79 389,-98"/>
+<text text-anchor="middle" x="327.5" y="-86" font-family="arial" font-size="10.00">subject.Subject.Protocol</text>
+</a>
+</g>
+</g>
+<!-- subject.Allele -->
+<g id="node13" class="node"><title>subject.Allele</title>
+<g id="a_node13"><a xlink:title="allele               ------------------------------allele_standard_name=&quot;&quot; ">
+<polygon fill="#000000" fill-opacity="0.125490" stroke="none" points="1388,-177 1313,-177 1313,-142 1388,-142 1388,-177"/>
+<text text-anchor="start" x="1321" y="-158" font-family="arial" text-decoration="underline" font-size="10.00">subject.Allele</text>
+</a>
+</g>
+</g>
+<!-- subject.Allele&#45;&gt;subject.Line.Allele -->
+<g id="edge5" class="edge"><title>subject.Allele-&gt;subject.Line.Allele</title>
+<path fill="none" stroke="#000000" stroke-width="0.75" stroke-opacity="0.250980" d="M1321.52,-141.973C1297.33,-128.178 1263.81,-109.064 1244.62,-98.1206"/>
+</g>
+<!-- subject.Allele&#45;&gt;subject.Zygosity -->
+<g id="edge6" class="edge"><title>subject.Allele-&gt;subject.Zygosity</title>
+<path fill="none" stroke="#000000" stroke-width="0.75" stroke-opacity="0.250980" d="M1312.95,-147.567C1272.48,-135.787 1207.9,-116.985 1163.24,-103.982"/>
+</g>
+<!-- subject.Allele&#45;&gt;subject.Allele.Source -->
+<g id="edge7" class="edge"><title>subject.Allele-&gt;subject.Allele.Source</title>
+<path fill="none" stroke="#000000" stroke-width="2" stroke-opacity="0.250980" d="M1350.5,-141.797C1350.5,-128.077 1350.5,-109.185 1350.5,-98.2652"/>
+</g>
+<!-- subject.Subject -->
+<g id="node15" class="node"><title>subject.Subject</title>
+<g id="a_node15"><a xlink:title="subject              ------------------------------subject_nickname=&quot;&quot;  sex                  subject_birth_date   subject_description=&quot;&quot; ">
+<polygon fill="#00ff00" fill-opacity="0.188235" stroke="#00ff00" stroke-opacity="0.188235" points="645,-177 550,-177 550,-142 645,-142 645,-177"/>
+<text text-anchor="start" x="558" y="-157.4" font-family="arial" text-decoration="underline" font-size="12.00" fill="darkgreen">subject.Subject</text>
+</a>
+</g>
+</g>
+<!-- subject.Subject&#45;&gt;subject.Subject.Source -->
+<g id="edge8" class="edge"><title>subject.Subject-&gt;subject.Subject.Source</title>
+<path fill="none" stroke="#000000" stroke-width="2" stroke-opacity="0.250980" d="M566.122,-141.973C539.932,-128.178 503.644,-109.064 482.867,-98.1206"/>
+</g>
+<!-- subject.Subject&#45;&gt;subject.Subject.User -->
+<g id="edge9" class="edge"><title>subject.Subject-&gt;subject.Subject.User</title>
+<path fill="none" stroke="#000000" stroke-width="0.75" stroke-opacity="0.250980" d="M597.5,-141.797C597.5,-128.077 597.5,-109.185 597.5,-98.2652"/>
+</g>
+<!-- subject.Subject&#45;&gt;subject.Subject.Species -->
+<g id="edge10" class="edge"><title>subject.Subject-&gt;subject.Subject.Species</title>
+<path fill="none" stroke="#000000" stroke-width="2" stroke-opacity="0.250980" d="M629.357,-141.973C655.947,-128.178 692.789,-109.064 713.884,-98.1206"/>
+</g>
+<!-- subject.Subject&#45;&gt;subject.SubjectDeath -->
+<g id="edge11" class="edge"><title>subject.Subject-&gt;subject.SubjectDeath</title>
+<path fill="none" stroke="#000000" stroke-width="2" stroke-opacity="0.250980" d="M549.698,-154.847C465.561,-148.021 285.691,-131.66 135.5,-106 132.719,-105.525 129.884,-105.01 127.026,-104.464"/>
+</g>
+<!-- subject.Subject&#45;&gt;subject.Subject.Lab -->
+<g id="edge12" class="edge"><title>subject.Subject-&gt;subject.Subject.Lab</title>
+<path fill="none" stroke="#000000" stroke-width="0.75" stroke-opacity="0.250980" d="M549.742,-152.918C483.502,-144.774 360.179,-128.16 256.5,-106 246.147,-103.787 234.927,-100.851 225.022,-98.0685"/>
+</g>
+<!-- subject.Subject&#45;&gt;subject.Zygosity -->
+<g id="edge13" class="edge"><title>subject.Subject-&gt;subject.Zygosity</title>
+<path fill="none" stroke="#000000" stroke-width="0.75" stroke-opacity="0.250980" d="M645.035,-155.614C728.669,-149.969 907.317,-135.367 1055.5,-106 1058.27,-105.451 1061.11,-104.833 1063.96,-104.169"/>
+</g>
+<!-- subject.Subject&#45;&gt;subject.Subject.Strain -->
+<g id="edge14" class="edge"><title>subject.Subject-&gt;subject.Subject.Strain</title>
+<path fill="none" stroke="#000000" stroke-width="2" stroke-opacity="0.250980" d="M645.282,-146.244C699.331,-132.38 785.951,-110.161 833.168,-98.0497"/>
+</g>
+<!-- subject.Subject&#45;&gt;subject.Subject.Protocol -->
+<g id="edge15" class="edge"><title>subject.Subject-&gt;subject.Subject.Protocol</title>
+<path fill="none" stroke="#000000" stroke-width="0.75" stroke-opacity="0.250980" d="M549.851,-146.323C495.653,-132.473 408.539,-110.21 361.037,-98.0706"/>
+</g>
+<!-- subject.Subject&#45;&gt;subject.Subject.Line -->
+<g id="edge16" class="edge"><title>subject.Subject-&gt;subject.Subject.Line</title>
+<path fill="none" stroke="#000000" stroke-width="2" stroke-opacity="0.250980" d="M645.075,-152.61C710.116,-144.196 830.275,-127.364 931.5,-106 942.18,-103.746 953.77,-100.799 964.006,-98.0213"/>
 </g>
 </g>
 </svg>


### PR DESCRIPTION
This PR adds a `Species` part table to the `Subject` table in `subject.py`. 

Since DANDI requires species information in the NWB file for each subject, this PR is a step towards improving the NWB export function in this Element. A future PR will incorporate this table into the `subject_to_nwb` function.