### PR TITLE
Fix tiny NWB export bug - .fetch1() from Subject.Species

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 Observes [Semantic Versioning](https://semver.org/spec/v2.0.0.html) standard and
 [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) convention.
 
+## [0.2.2] - 2025-05-14
++ Fix - NWB export - `.fetch1()` from `Subject.Species` table
+
 ## [0.2.1] - 2023-11-28
 + Add - `Species` table in `subject` schema
 

--- a/element_animal/export/nwb.py
+++ b/element_animal/export/nwb.py
@@ -30,7 +30,7 @@ def subject_to_nwb(session_key: dict):
             datetime.strptime("00:00:00", "%H:%M:%S").time(),
         ),
         description=json.dumps(subject_info, default=str),
-        species=str((subject.Species & subject_query).fetch("species")),
+        species=str((subject.Species & subject_query).fetch1("species")),
         genotype=" x ".join(
             (subject.Line.Allele * subject.Subject.Line & subject_query).fetch("allele")
         ),

--- a/element_animal/version.py
+++ b/element_animal/version.py
@@ -1,2 +1,2 @@
 """Package metadata."""
-__version__ = "0.2.1"
+__version__ = "0.2.2"


### PR DESCRIPTION
This pull request includes a bug fix for the NWB export functionality and updates the version and changelog to reflect the new release.

### Bug Fix:
* [`element_animal/export/nwb.py`](diffhunk://#diff-9d94d44039b9bec223321fdd5727c795d55cd2fe63e61598c03f13cf36b8c6b3L33-R33): Corrected the query to use `.fetch1()` instead of `.fetch()` when retrieving the species from the `Subject.Species` table, ensuring the correct single value is fetched.